### PR TITLE
Create a function that builds an optmised version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ run_test_nochecks:
 	@echo "\nRunning Tests - No Check\n"
 	@sh test/runTestNochecks.sh
 
+run_test_build:
+	@echo "\nRunning Tests - Build function\n"
+	@sh test/runTestBuildVersioningFunction.sh
+
 
 performance_test:
 	@echo "\nDB Setup\n"

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,27 @@ performance_test:
 	@psql temporal_tables_test -q -f test/performance/teardown.sql
 	@psql -q -c "drop database temporal_tables_test;"
 
+performance_test_optimised:
+	@echo "\nDB Setup\n"
+	@createdb temporal_tables_test
+	@psql temporal_tables_test -q -f build_versioning_function.sql
+	@psql temporal_tables_test -q -f test/performance/setup_optimised.sql
+
+	@echo "\nRun Test OPTIMISED\n"
+
+	@echo "Insert"
+	@psql temporal_tables_test -q -f test/performance/insert.sql
+
+	@echo "Update"
+	@psql temporal_tables_test -q -f test/performance/update.sql
+
+	@echo "Delete"
+	@psql temporal_tables_test -q -f test/performance/delete.sql
+
+	@echo "\nDB teardown\n"
+	@psql -q -c "drop database temporal_tables_test;"
+
+
 performance_test_nochecks:
 	@echo "\nDB Setup\n"
 	@createdb temporal_tables_test
@@ -48,7 +69,6 @@ performance_test_nochecks:
 	@echo "\nDB teardown\n"
 	@psql temporal_tables_test -q -f test/performance/teardown.sql
 	@psql -q -c "drop database temporal_tables_test;"
-
 
 performance_test_original:
 	@echo "\nDB Setup\n"

--- a/build_versioning_function.sql
+++ b/build_versioning_function.sql
@@ -1,0 +1,193 @@
+CREATE OR REPLACE FUNCTION build_versioning(function_name text, original_table text, history_table text, sys_period text, adjust_time boolean)
+RETURNS VOID AS $outer$
+DECLARE
+  commonColumns text[];
+  holder record;
+  holder2 record;
+  queryTemplate text;
+  adjust_time_check text;
+BEGIN
+  -- version 0.0.1
+
+  -- check if original table exits
+  IF to_regclass(original_table) IS NULL THEN
+    RAISE 'relation "%" does not exist', original_table;
+  END IF;
+
+  -- check if history table exits
+  IF to_regclass(history_table) IS NULL THEN
+    RAISE 'relation "%" does not exist', history_table;
+  END IF;
+
+  -- check if sys_period exists on original table
+  SELECT atttypid, attndims INTO holder FROM pg_attribute WHERE attrelid = original_table::regclass AND attname = sys_period AND NOT attisdropped;
+  IF NOT FOUND THEN
+    RAISE 'column "%" of relation "%" does not exist', sys_period, original_table USING
+    ERRCODE = 'undefined_column';
+  END IF;
+  IF holder.atttypid != to_regtype('tstzrange') THEN
+    IF holder.attndims > 0 THEN
+      RAISE 'system period column "%" of relation "%" is not a range but an array', sys_period, original_table USING
+      ERRCODE = 'datatype_mismatch';
+    END IF;
+
+    SELECT rngsubtype INTO holder2 FROM pg_range WHERE rngtypid = holder.atttypid;
+    IF FOUND THEN
+      RAISE 'system period column "%" of relation "%" is not a range of timestamp with timezone but of type %', sys_period, original_table, format_type(holder2.rngsubtype, null) USING
+      ERRCODE = 'datatype_mismatch';
+    END IF;
+
+    RAISE 'system period column "%" of relation "%" is not a range but type %', sys_period, original_table, format_type(holder.atttypid, null) USING
+    ERRCODE = 'datatype_mismatch';
+  END IF;
+
+  -- check if history table has sys_period
+  IF NOT EXISTS(SELECT * FROM pg_attribute WHERE attrelid = history_table::regclass AND attname = sys_period AND NOT attisdropped) THEN
+    RAISE 'history relation "%" does not contain system period column "%"', history_table, sys_period USING
+    HINT = 'history relation must contain system period column with the same name and data type as the versioned one';
+  END IF;
+
+  -- check if column types on original table are different from ones in history table
+  WITH history AS
+    (SELECT attname, atttypid
+    FROM   pg_attribute
+    WHERE  attrelid = history_table::regclass
+    AND    attnum > 0
+    AND    NOT attisdropped),
+    main AS
+    (SELECT attname, atttypid
+    FROM   pg_attribute
+    WHERE  attrelid = original_table::regclass
+    AND    attnum > 0
+    AND    NOT attisdropped)
+  SELECT
+    history.attname AS history_name,
+    main.attname AS main_name,
+    history.atttypid AS history_type,
+    main.atttypid AS main_type
+  INTO holder
+    FROM history
+    INNER JOIN main
+    ON history.attname = main.attname
+  WHERE
+    history.atttypid != main.atttypid;
+
+  IF FOUND THEN
+    RAISE 'column "%" of relation "%" is of type % but column "%" of history relation "%" is of type %',
+      holder.main_name, original_table, format_type(holder.main_type, null), holder.history_name, history_table, format_type(holder.history_type, null)
+    USING ERRCODE = 'datatype_mismatch';
+  END IF;
+
+  -- load common columns
+  WITH history AS
+    (SELECT attname
+    FROM   pg_attribute
+    WHERE  attrelid = history_table::regclass
+    AND    attnum > 0
+    AND    NOT attisdropped),
+    main AS
+    (SELECT attname
+    FROM   pg_attribute
+    WHERE  attrelid = original_table::regclass
+    AND    attnum > 0
+    AND    NOT attisdropped)
+  SELECT array_agg(quote_ident(history.attname)) INTO commonColumns
+    FROM history
+    INNER JOIN main
+    ON history.attname = main.attname
+    AND history.attname != sys_period;
+
+  -- create function
+  queryTemplate := $template$
+    CREATE OR REPLACE FUNCTION {function_name}()
+    RETURNS TRIGGER AS $inner$
+    DECLARE
+      time_stamp_to_use timestamptz := current_timestamp;
+      range_lower timestamptz;
+      transaction_info txid_snapshot;
+      existing_range tstzrange;
+    BEGIN
+      -- version 0.0.1
+
+      IF TG_TABLE_NAME != '{original_table}' THEN
+        RAISE TRIGGER_PROTOCOL_VIOLATED USING
+        MESSAGE = 'function "{function_name}" to wrong table';
+      END IF;
+
+      IF TG_WHEN != 'BEFORE' OR TG_LEVEL != 'ROW' THEN
+        RAISE TRIGGER_PROTOCOL_VIOLATED USING
+        MESSAGE = 'function "{function_name}" must be fired BEFORE ROW';
+      END IF;
+
+      IF TG_OP != 'INSERT' AND TG_OP != 'UPDATE' AND TG_OP != 'DELETE' THEN
+        RAISE TRIGGER_PROTOCOL_VIOLATED USING
+        MESSAGE = 'function "{function_name}" must be fired for INSERT or UPDATE or DELETE';
+      END IF;
+
+      IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
+        -- Ignore rows already modified in this transaction
+        transaction_info := txid_current_snapshot();
+        IF OLD.xmin::text >= (txid_snapshot_xmin(transaction_info) % (2^32)::bigint)::text
+        AND OLD.xmin::text <= (txid_snapshot_xmax(transaction_info) % (2^32)::bigint)::text THEN
+          IF TG_OP = 'DELETE' THEN
+            RETURN OLD;
+          END IF;
+
+          RETURN NEW;
+        END IF;
+
+        SELECT OLD.{sys_period} INTO existing_range;
+
+        IF existing_range IS NULL THEN
+          RAISE 'system period column "{sys_period}" of relation "{original_table}" must not be null' USING
+          ERRCODE = 'null_value_not_allowed';
+        END IF;
+
+        IF isempty(existing_range) OR NOT upper_inf(existing_range) THEN
+          RAISE 'system period column "{sys_period}" of relation "{original_table}" contains invalid value' USING
+          ERRCODE = 'data_exception',
+          DETAIL = 'valid ranges must be non-empty and unbounded on the high side';
+        END IF;
+
+        range_lower := lower(existing_range);
+        {adjust_time_check}
+
+        INSERT INTO {history_table} ({original_table_columns}, {quoted_sys_period}) VALUES ({query_values}, tstzrange(range_lower, time_stamp_to_use, '[)'));
+      END IF;
+
+      IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' THEN
+        NEW.{sys_period} = tstzrange(time_stamp_to_use, null, '[)');
+
+        RETURN NEW;
+      END IF;
+
+      RETURN OLD;
+    END;
+    $inner$ LANGUAGE plpgsql;
+  $template$;
+
+
+  adjust_time_check := '';
+  IF adjust_time THEN
+    adjust_time_check := $time_check$
+      -- mitigate update conflicts
+      IF range_lower >= time_stamp_to_use THEN
+        time_stamp_to_use := range_lower + interval '1 microseconds';
+      END IF;
+    $time_check$;
+  END IF;
+
+  queryTemplate = replace(queryTemplate, '{function_name}', function_name);
+  queryTemplate = replace(queryTemplate, '{original_table}', original_table);
+  queryTemplate = replace(queryTemplate, '{history_table}', history_table);
+  queryTemplate = replace(queryTemplate, '{sys_period}', sys_period);
+  queryTemplate = replace(queryTemplate, '{quoted_sys_period}', quote_ident(sys_period));
+  queryTemplate = replace(queryTemplate, '{original_table_columns}', array_to_string(commonColumns , ','));
+  queryTemplate = replace(queryTemplate, '{query_values}', 'OLD.' || array_to_string(commonColumns, ',OLD.'));
+  queryTemplate = replace(queryTemplate, '{adjust_time_check}', adjust_time_check);
+
+  EXECUTE queryTemplate;
+
+  RETURN;
+END;
+$outer$ LANGUAGE plpgsql;

--- a/build_versioning_function.sql
+++ b/build_versioning_function.sql
@@ -10,12 +10,12 @@ BEGIN
   -- version 0.0.1
 
   -- check if original table exits
-  IF to_regclass(original_table) IS NULL THEN
+  IF to_regclass(original_table::cstring) IS NULL THEN
     RAISE 'relation "%" does not exist', original_table;
   END IF;
 
   -- check if history table exits
-  IF to_regclass(history_table) IS NULL THEN
+  IF to_regclass(history_table::cstring) IS NULL THEN
     RAISE 'relation "%" does not exist', history_table;
   END IF;
 

--- a/test/expected/combinations_build.out
+++ b/test/expected/combinations_build.out
@@ -1,0 +1,112 @@
+CREATE TABLE versioning (a bigint, "b b" date, sys_period tstzrange);
+-- Insert some data before versioning is enabled.
+INSERT INTO versioning (a, sys_period) VALUES (1, tstzrange('-infinity', NULL));
+INSERT INTO versioning (a, sys_period) VALUES (2, tstzrange('2000-01-01', NULL));
+CREATE TABLE versioning_history (a bigint, "b b" date, c date, sys_period tstzrange);
+SELECT build_versioning('versioning', 'versioning', 'versioning_history', 'sys_period', false);
+ build_versioning
+------------------
+
+(1 row)
+
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning
+FOR EACH ROW EXECUTE PROCEDURE versioning();
+-- Insert + Update.
+BEGIN;
+INSERT INTO versioning (a) VALUES (3);
+UPDATE versioning SET a = 4 WHERE a = 3;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+ a | b b | ?column?
+---+-----+----------
+ 1 |     | f
+ 2 |     | f
+ 4 |     | t
+(3 rows)
+
+SELECT * FROM versioning_history ORDER BY a, sys_period;
+ a | b b | c | sys_period
+---+-----+---+------------
+(0 rows)
+
+COMMIT;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep
+----------
+
+(1 row)
+
+-- Multiple updates.
+BEGIN;
+UPDATE versioning SET a = 5 WHERE a = 4;
+UPDATE versioning SET "b b" = '2012-01-01' WHERE a = 5;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+ a |    b b     | ?column?
+---+------------+----------
+ 1 |            | f
+ 2 |            | f
+ 5 | 2012-01-01 | t
+(3 rows)
+
+SELECT a, "b b", c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+ a | b b | c | ?column?
+---+-----+---+----------
+ 4 |     |   | t
+(1 row)
+
+COMMIT;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep
+----------
+
+(1 row)
+
+-- Insert + Delete.
+BEGIN;
+INSERT INTO versioning (a) VALUES (6);
+DELETE FROM versioning WHERE a = 6;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+ a |    b b     | ?column?
+---+------------+----------
+ 1 |            | f
+ 2 |            | f
+ 5 | 2012-01-01 | f
+(3 rows)
+
+SELECT a, "b b", c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+ a | b b | c | ?column?
+---+-----+---+----------
+ 4 |     |   | f
+(1 row)
+
+END;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep
+----------
+
+(1 row)
+
+-- Update + Delete.
+BEGIN;
+UPDATE versioning SET "b b" = '2015-01-01' WHERE a = 5;
+DELETE FROM versioning WHERE a = 5;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+ a | b b | ?column?
+---+-----+----------
+ 1 |     | f
+ 2 |     | f
+(2 rows)
+
+SELECT a, "b b", c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+ a |    b b     | c | ?column?
+---+------------+---+----------
+ 4 |            |   | f
+ 5 | 2012-01-01 |   | t
+(2 rows)
+
+END;
+DROP TABLE versioning;
+DROP TABLE versioning_history;

--- a/test/expected/structure_build.out
+++ b/test/expected/structure_build.out
@@ -1,0 +1,49 @@
+CREATE TABLE structure (a bigint, "b b" date, d text, sys_period tstzrange);
+CREATE TABLE structure_history (like structure);
+SELECT build_versioning('versioning', 'structure', 'structure_history', 'sys_period', false);
+ build_versioning
+------------------
+
+(1 row)
+
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON structure
+FOR EACH ROW EXECUTE PROCEDURE versioning();
+-- Insert.
+BEGIN;
+INSERT INTO structure (a, "b b", d) VALUES (1, '2000-01-01', 'test');
+SELECT a, "b b", d FROM structure ORDER BY a, sys_period;
+ a |    b b     |  d
+---+------------+------
+ 1 | 2000-01-01 | test
+(1 row)
+
+SELECT * FROM structure_history ORDER BY a, sys_period;
+ a | b b | d | sys_period
+---+-----+---+------------
+(0 rows)
+
+COMMIT;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep
+----------
+
+(1 row)
+
+-- Update.
+BEGIN;
+UPDATE structure SET d = 'blah' WHERE a = 1;
+SELECT a, "b b", d FROM structure ORDER BY a, sys_period;
+ a |    b b     |  d
+---+------------+------
+ 1 | 2000-01-01 | blah
+(1 row)
+
+SELECT a, "b b", d FROM structure_history ORDER BY a, sys_period;
+ a |    b b     |  d
+---+------------+------
+ 1 | 2000-01-01 | test
+(1 row)
+
+COMMIT;

--- a/test/expected/versioning_build.out
+++ b/test/expected/versioning_build.out
@@ -1,0 +1,159 @@
+CREATE TABLE versioning (a bigint, "b b" date, sys_period tstzrange);
+-- Insert some data before versioning is enabled.
+INSERT INTO versioning (a, sys_period) VALUES (1, tstzrange('-infinity', NULL));
+INSERT INTO versioning (a, sys_period) VALUES (2, tstzrange('2000-01-01', NULL));
+CREATE TABLE versioning_history (a bigint, c date, sys_period tstzrange);
+SELECT build_versioning('versioning', 'versioning', 'versioning_history', 'sys_period', false);
+ build_versioning
+------------------
+
+(1 row)
+
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning
+FOR EACH ROW EXECUTE PROCEDURE versioning();
+-- Insert.
+BEGIN;
+INSERT INTO versioning (a) VALUES (3);
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+ a | b b | ?column?
+---+-----+----------
+ 1 |     | f
+ 2 |     | f
+ 3 |     | t
+(3 rows)
+
+SELECT * FROM versioning_history ORDER BY a, sys_period;
+ a | c | sys_period
+---+---+------------
+(0 rows)
+
+COMMIT;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep
+----------
+
+(1 row)
+
+-- Update.
+BEGIN;
+UPDATE versioning SET a = 4 WHERE a = 3;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+ a | b b | ?column?
+---+-----+----------
+ 1 |     | f
+ 2 |     | f
+ 4 |     | t
+(3 rows)
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+ a | c | ?column?
+---+---+----------
+ 3 |   | t
+(1 row)
+
+SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+ a | b b
+---+-----
+ 4 |
+(1 row)
+
+COMMIT;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep
+----------
+
+(1 row)
+
+-- Multiple updates.
+BEGIN;
+UPDATE versioning SET a = 5 WHERE a = 4;
+UPDATE versioning SET "b b" = '2012-01-01' WHERE a = 5;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+ a |    b b     | ?column?
+---+------------+----------
+ 1 |            | f
+ 2 |            | f
+ 5 | 2012-01-01 | t
+(3 rows)
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+ a | c | ?column?
+---+---+----------
+ 3 |   | f
+ 4 |   | t
+(2 rows)
+
+SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+ a |    b b
+---+------------
+ 5 | 2012-01-01
+(1 row)
+
+COMMIT;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep
+----------
+
+(1 row)
+
+-- Delete.
+BEGIN;
+DELETE FROM versioning WHERE a = 4;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+ a |    b b     | ?column?
+---+------------+----------
+ 1 |            | f
+ 2 |            | f
+ 5 | 2012-01-01 | f
+(3 rows)
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+ a | c | ?column?
+---+---+----------
+ 3 |   | f
+ 4 |   | f
+(2 rows)
+
+SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+ a | b b
+---+-----
+(0 rows)
+
+END;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep
+----------
+
+(1 row)
+
+-- Delete.
+BEGIN;
+DELETE FROM versioning;
+SELECT * FROM versioning;
+ a | b b | sys_period
+---+-----+------------
+(0 rows)
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+ a | c | ?column?
+---+---+----------
+ 1 |   | t
+ 2 |   | t
+ 3 |   | f
+ 4 |   | f
+ 5 |   | t
+(5 rows)
+
+SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+ a | b b
+---+-----
+(0 rows)
+
+END;
+DROP TABLE versioning;
+DROP TABLE versioning_history;

--- a/test/performance/setup_optimised.sql
+++ b/test/performance/setup_optimised.sql
@@ -1,0 +1,17 @@
+\timing off
+
+CREATE TABLE subscriptions
+(
+  name text NOT NULL,
+  state text NOT NULL,
+  sys_period tstzrange NOT NULL DEFAULT tstzrange(current_timestamp, null)
+);
+
+CREATE TABLE subscriptions_history (LIKE subscriptions);
+
+SELECT build_versioning('optimised_versioning', 'subscriptions', 'subscriptions_history', 'sys_period', true);
+
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON subscriptions
+FOR EACH ROW EXECUTE PROCEDURE optimised_versioning();
+

--- a/test/runTestBuildVersioningFunction.sh
+++ b/test/runTestBuildVersioningFunction.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+createdb temporal_tables_test
+psql temporal_tables_test -q -f build_versioning_function.sql
+
+mkdir -p test/result
+
+TESTS="versioning_build structure_build combinations_build"
+
+for name in $TESTS; do
+  echo ""
+  echo $name
+  echo ""
+  psql temporal_tables_test -X -a -q --set=SHOW_CONTEXT=never < test/sql/$name.sql > test/result/$name.out 2>&1
+  diff -b test/expected/$name.out test/result/$name.out
+done
+
+
+psql -q -c "drop database temporal_tables_test;"

--- a/test/sql/combinations_build.sql
+++ b/test/sql/combinations_build.sql
@@ -1,0 +1,77 @@
+CREATE TABLE versioning (a bigint, "b b" date, sys_period tstzrange);
+
+-- Insert some data before versioning is enabled.
+INSERT INTO versioning (a, sys_period) VALUES (1, tstzrange('-infinity', NULL));
+INSERT INTO versioning (a, sys_period) VALUES (2, tstzrange('2000-01-01', NULL));
+
+CREATE TABLE versioning_history (a bigint, "b b" date, c date, sys_period tstzrange);
+
+SELECT build_versioning('versioning', 'versioning', 'versioning_history', 'sys_period', false);
+
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning
+FOR EACH ROW EXECUTE PROCEDURE versioning();
+
+-- Insert + Update.
+BEGIN;
+
+INSERT INTO versioning (a) VALUES (3);
+
+UPDATE versioning SET a = 4 WHERE a = 3;
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+
+SELECT * FROM versioning_history ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Multiple updates.
+BEGIN;
+
+UPDATE versioning SET a = 5 WHERE a = 4;
+
+UPDATE versioning SET "b b" = '2012-01-01' WHERE a = 5;
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+
+SELECT a, "b b", c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Insert + Delete.
+BEGIN;
+
+INSERT INTO versioning (a) VALUES (6);
+
+DELETE FROM versioning WHERE a = 6;
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+
+SELECT a, "b b", c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+
+END;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Update + Delete.
+BEGIN;
+
+UPDATE versioning SET "b b" = '2015-01-01' WHERE a = 5;
+
+DELETE FROM versioning WHERE a = 5;
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+
+SELECT a, "b b", c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+
+END;
+
+DROP TABLE versioning;
+DROP TABLE versioning_history;

--- a/test/sql/structure_build.sql
+++ b/test/sql/structure_build.sql
@@ -1,0 +1,34 @@
+CREATE TABLE structure (a bigint, "b b" date, d text, sys_period tstzrange);
+
+CREATE TABLE structure_history (like structure);
+
+SELECT build_versioning('versioning', 'structure', 'structure_history', 'sys_period', false);
+
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON structure
+FOR EACH ROW EXECUTE PROCEDURE versioning();
+
+-- Insert.
+BEGIN;
+
+INSERT INTO structure (a, "b b", d) VALUES (1, '2000-01-01', 'test');
+
+SELECT a, "b b", d FROM structure ORDER BY a, sys_period;
+
+SELECT * FROM structure_history ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Update.
+BEGIN;
+
+UPDATE structure SET d = 'blah' WHERE a = 1;
+
+SELECT a, "b b", d FROM structure ORDER BY a, sys_period;
+
+SELECT a, "b b", d FROM structure_history ORDER BY a, sys_period;
+
+COMMIT;

--- a/test/sql/versioning_build.sql
+++ b/test/sql/versioning_build.sql
@@ -1,0 +1,92 @@
+CREATE TABLE versioning (a bigint, "b b" date, sys_period tstzrange);
+
+-- Insert some data before versioning is enabled.
+INSERT INTO versioning (a, sys_period) VALUES (1, tstzrange('-infinity', NULL));
+INSERT INTO versioning (a, sys_period) VALUES (2, tstzrange('2000-01-01', NULL));
+
+CREATE TABLE versioning_history (a bigint, c date, sys_period tstzrange);
+
+SELECT build_versioning('versioning', 'versioning', 'versioning_history', 'sys_period', false);
+
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning
+FOR EACH ROW EXECUTE PROCEDURE versioning();
+
+-- Insert.
+BEGIN;
+
+INSERT INTO versioning (a) VALUES (3);
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+
+SELECT * FROM versioning_history ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Update.
+BEGIN;
+
+UPDATE versioning SET a = 4 WHERE a = 3;
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+
+SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Multiple updates.
+BEGIN;
+
+UPDATE versioning SET a = 5 WHERE a = 4;
+UPDATE versioning SET "b b" = '2012-01-01' WHERE a = 5;
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+
+SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Delete.
+BEGIN;
+
+DELETE FROM versioning WHERE a = 4;
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+
+SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+
+END;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Delete.
+BEGIN;
+
+DELETE FROM versioning;
+
+SELECT * FROM versioning;
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
+
+SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+
+END;
+
+DROP TABLE versioning;
+DROP TABLE versioning_history;


### PR DESCRIPTION
I initially dropped the idea of an "optimised" version of the versioning function because of two main reasons:
- fragility: the way to "optimised" the function was to make assumptions on table names and structure so that we could avoid building and executing queries dynamically. This also meant that any change to the versioned tables would break the versioning function in unexpected - and sometime undetected - ways
- minimal performance gains: depending on the amount of assumptions made, some check would still need to be performed at run time (e.g. checking the common columns between original table and history table)

During the Week End I had a change of mind and searched for possible ways to implement this feature as safe as possible and this morning I coded this proof of concept.

The idea is to have a function that creates a "versioning" function customised for each table. Most of the check, including loading the common columns between original and history table is performed at build time and a completely static function is created.

This is the part I implemented in this PR, and it works. It quite fast, being only 1.5 to 2 times slower than the original c version.

Downsides of this version are:
1) it must be re-built every time a change to the original or historical table is made.
2) security issues: a user gaining access to the "build_versioning" function could create harmful versions

Mitigations
1) This can be mitigated using "DDL Triggers" that is, trigger called on "alter table" commands. The new usage would be something like calling a function "enable_versioning_on_table('table')": this would create the versioning function and the trigger to update it on every table change.
Unfortunately I'm not familiar with DDL Triggers so I'm not sure if those cover all possible source of changes for a table (e.g. how do they apply to restoring a backup?)
2) I could argue that if an attacker gets access to the build_versioning function the db is already compromised and custom functions could already be created without the need for build_versioning

Additional work to be done to complete this PR, if adopted:
- custom test suite to check that 1) behaviour is equal to the original (where applicable) and 2) creation of the function work as expected and return errors when due
- update of README
