### PR TITLE
Ensure `to_regclass` is being called with a `cstring`

### DIFF
--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -68,7 +68,7 @@ BEGIN
     END IF;
 
     -- check if history table exits
-    IF to_regclass(history_table) IS NULL THEN
+    IF to_regclass(history_table::cstring) IS NULL THEN
       RAISE 'relation "%" does not exist', history_table;
     END IF;
 


### PR DESCRIPTION
I was getting the following error when using the function in `postgrator` migrations on PG 9.6 and below:

```
error: function to_regclass(text) does not exist
```

After some [research](https://stackoverflow.com/a/31650242) I found that this was a good workaround.

Note: I've only tested 9.6 and 9.5, this could be entirely scoped to the way `postgrator` runs migrations.