### PR TITLE
Working fully qualified table name and tables in different schema from function

### DIFF
--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -11,6 +11,7 @@ DECLARE
   existing_range tstzrange;
   holder record;
   holder2 record;
+  pg_version integer;
 BEGIN
   -- version 0.0.1
 
@@ -67,9 +68,19 @@ BEGIN
       RETURN NEW;
     END IF;
 
-    -- check if history table exits
-    IF to_regclass(history_table::cstring) IS NULL THEN
-      RAISE 'relation "%" does not exist', history_table;
+    SELECT current_setting('server_version_num')::integer
+    INTO pg_version;
+
+    -- to support postgres < 9.6
+    IF pg_version < 90600 THEN
+      -- check if history table exits
+      IF to_regclass(history_table::cstring) IS NULL THEN
+        RAISE 'relation "%" does not exist', history_table;
+      END IF;
+    ELSE
+      IF to_regclass(history_table) IS NULL THEN
+        RAISE 'relation "%" does not exist', history_table;
+      END IF;
     END IF;
 
     -- check if history table has sys_period

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -34,7 +34,7 @@ BEGIN
   history_table := TG_ARGV[1];
 
   -- check if sys_period exists on original table
-  SELECT atttypid, attndims INTO holder FROM pg_attribute WHERE attrelid = TG_TABLE_NAME::regclass AND attname = sys_period AND NOT attisdropped;
+  SELECT atttypid, attndims INTO holder FROM pg_attribute WHERE attrelid = TG_RELID AND attname = sys_period AND NOT attisdropped;
   IF NOT FOUND THEN
     RAISE 'column "%" of relation "%" does not exist', sys_period, TG_TABLE_NAME USING
     ERRCODE = 'undefined_column';
@@ -68,7 +68,7 @@ BEGIN
     END IF;
 
     -- check if history table exits
-    IF to_regclass(history_table) IS NULL THEN
+    IF to_regclass(history_table::cstring) IS NULL THEN
       RAISE 'relation "%" does not exist', history_table;
     END IF;
 
@@ -108,7 +108,7 @@ BEGIN
       main AS
       (SELECT attname, atttypid
       FROM   pg_attribute
-      WHERE  attrelid = TG_TABLE_NAME::regclass
+      WHERE  attrelid = TG_RELID
       AND    attnum > 0
       AND    NOT attisdropped)
     SELECT
@@ -138,7 +138,7 @@ BEGIN
       main AS
       (SELECT attname
       FROM   pg_attribute
-      WHERE  attrelid = TG_TABLE_NAME::regclass
+      WHERE  attrelid = TG_RELID
       AND    attnum > 0
       AND    NOT attisdropped)
     SELECT array_agg(quote_ident(history.attname)) INTO commonColumns
@@ -148,7 +148,12 @@ BEGIN
       AND history.attname != sys_period;
 
     EXECUTE ('INSERT INTO ' ||
-      quote_ident(history_table) ||
+      CASE split_part(history_table, '.', 2)
+      WHEN '' THEN
+        quote_ident(history_table)
+      ELSE
+        quote_ident(split_part(history_table, '.', 1)) || '.' || quote_ident(split_part(history_table, '.', 2))
+      END ||
       '(' ||
       array_to_string(commonColumns , ',') ||
       ',' ||


### PR DESCRIPTION
This is meant as a starting point to address #3.

Here's the example of trigger definition we've been using with temporal_tables native:

```sql
SET search_path TO schema_name, public;

CREATE TRIGGER tr_01_table_versioning
BEFORE UPDATE OR DELETE ON table
   FOR EACH ROW EXECUTE PROCEDURE versioning(
     'valid_between', 'schema_name.table_history', true
   );
```