### PR TITLE
Updated license to Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,13 @@
-The MIT License (MIT)
+Copyright 2018 nearForm
 
-Copyright (c) 2016-2017 Nearform and contributors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Contributors listed at https://github.com/nearform/temporal_tables#the-team and in
-the README file.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ This project was kindly sponsored by [nearForm](http://nearform.com).
 
 ## License
 
-Licensed under [MIT](./LICENSE).
+Copyright nearForm 2018. Licensed under 
+[Apache 2.0](<https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)>)
 
 The test scenarios in test/sql and test/expected have been copied over from the original temporal_tables extension, whose license is [BSD 2-clause](https://github.com/arkhipov/temporal_tables/blob/master/LICENSE)


### PR DESCRIPTION
Regarding the nearForm open-source guidelines, we should use Apache 2.0 license.

Source: https://github.com/nearform/pathfinders/blob/master/nearform-opensource-guidelines.md