### PR TITLE
Accept a sys_period (lower bound timestamp) override on insert and update

### DIFF
--- a/versioning_function_nochecks.sql
+++ b/versioning_function_nochecks.sql
@@ -29,9 +29,18 @@ BEGIN
 
     EXECUTE format('SELECT $1.%I', sys_period) USING OLD INTO existing_range;
 
+    range_lower := lower(existing_range);
+
+    IF TG_OP = 'UPDATE' THEN
+      -- On UPDATE we always have a NEW.sys_period, which equals OLD.sys_period [range_lower] if not explicitly set
+      IF NEW.sys_period IS NOT NULL AND lower(NEW.sys_period) > range_lower THEN
+        -- If given a sys_period, use it's lower bound instead of current_timestamp
+        time_stamp_to_use := lower(NEW.sys_period);
+      END IF;
+    END IF;
+
     IF TG_ARGV[2] = 'true' THEN
       -- mitigate update conflicts
-      range_lower := lower(existing_range);
       IF range_lower >= time_stamp_to_use THEN
         time_stamp_to_use := range_lower + interval '1 microseconds';
       END IF;
@@ -70,6 +79,13 @@ BEGIN
       array_to_string(commonColumns, ',$1.') ||
       ',tstzrange($2, $3, ''[)''))')
        USING OLD, range_lower, time_stamp_to_use;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    -- On INSERT we have a NEW.sys_period if explicitly given (or by default value for column)
+    IF NEW.sys_period IS NOT NULL THEN
+      time_stamp_to_use := lower(NEW.sys_period);
+    END IF;
   END IF;
 
   IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' THEN


### PR DESCRIPTION
This is my "hackjob" mod to allow passing custom `sys_period` in INSERT and UPDATE statements.
I skipped on writing tests for this, sorry.
Also not doing much verification of the passed `tstzrange` (e.g. if upper bound IS NULL, as it's not even used; but for validity it probably should check. I explicitly allowed myself to use future timestamps here, but checking against `current_timestamp` may be a good idea.)

In the performance testsuite I noted about 1000-2000ms slowdown for INSERTs, as the `not null default tstzrange` on the subscriptions table always fires the new if clause. (The UPDATEs didn't get a testcase, but slowdowns from the if-clause check itself were not noticeable.)

~

As per my requirements in https://github.com/nearform/temporal_tables/issues/6#issuecomment-417438423 (and linked issue https://github.com/arkhipov/temporal_tables/issues/41) this allows me to do

    INSERT INTO x ([...], tstzrange(my_time::timestamptz, NULL::timestamptz));
    UPDATE x SET sys_perid = tstzrange(my_time::timestamptz, NULL::timestamptz) WHERE [...];

and by additionally adding an ["upsert" trigger][1], also use dumb `COPY` to bulk-load data from multiple historical snapshots (backfill) through the versioning trigger; instead of stitching a history table. Which makes it a massive improvement over prefixing every INSERT/UPDATE with `SELECT set_system_time();` and allows me to use `pg_restore -a` for the backfill. :godmode:
Maybe someone else finds it useful.

Thanks for this project! I couldn't have managed this on the C extension.

[1]: https://stackoverflow.com/a/47563302/9214854