### PR TITLE
Update to versioning fn to handle schema

### DIFF
--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -1,7 +1,5 @@
 CREATE OR REPLACE FUNCTION versioning()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
+RETURNS TRIGGER AS $$
 DECLARE
   sys_period text;
   history_table text;
@@ -187,4 +185,4 @@ BEGIN
 
   RETURN OLD;
 END;
-$function$
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Update to versioning fn to handle being run under a schema not known when the trigger is created.

In our usage we use the function within a specific schema - this schema is not known when the trigger is defined. 