### PR TITLE
added a test case for tables in CamelCase

### DIFF
--- a/test/expected/versioning_camel_case.out
+++ b/test/expected/versioning_camel_case.out
@@ -1,0 +1,153 @@
+CREATE TABLE "Versioning" (a bigint, "b b" date, sys_period tstzrange);
+-- Insert some data before versioning is enabled.
+INSERT INTO "Versioning" (a, sys_period) VALUES (1, tstzrange('-infinity', NULL));
+INSERT INTO "Versioning" (a, sys_period) VALUES (2, tstzrange('2000-01-01', NULL));
+CREATE TABLE "VersioningHistory" (a bigint, c date, sys_period tstzrange);
+CREATE TRIGGER "VersioningTrigger"
+BEFORE INSERT OR UPDATE OR DELETE ON "Versioning"
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', '"VersioningHistory"', false);
+-- Insert.
+BEGIN;
+INSERT INTO "Versioning" (a) VALUES (3);
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM "Versioning" ORDER BY a, sys_period;
+ a | b b | ?column? 
+---+-----+----------
+ 1 |     | f
+ 2 |     | f
+ 3 |     | t
+(3 rows)
+
+SELECT * FROM "VersioningHistory" ORDER BY a, sys_period;
+ a | c | sys_period 
+---+---+------------
+(0 rows)
+
+COMMIT;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- Update.
+BEGIN;
+UPDATE "Versioning" SET a = 4 WHERE a = 3;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM "Versioning" ORDER BY a, sys_period;
+ a | b b | ?column? 
+---+-----+----------
+ 1 |     | f
+ 2 |     | f
+ 4 |     | t
+(3 rows)
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM "VersioningHistory" ORDER BY a, sys_period;
+ a | c | ?column? 
+---+---+----------
+ 3 |   | t
+(1 row)
+
+SELECT a, "b b" FROM "Versioning" WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+ a | b b 
+---+-----
+ 4 | 
+(1 row)
+
+COMMIT;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- Multiple updates.
+BEGIN;
+UPDATE "Versioning" SET a = 5 WHERE a = 4;
+UPDATE "Versioning" SET "b b" = '2012-01-01' WHERE a = 5;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM "Versioning" ORDER BY a, sys_period;
+ a |    b b     | ?column? 
+---+------------+----------
+ 1 |            | f
+ 2 |            | f
+ 5 | 2012-01-01 | t
+(3 rows)
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM "VersioningHistory" ORDER BY a, sys_period;
+ a | c | ?column? 
+---+---+----------
+ 3 |   | f
+ 4 |   | t
+(2 rows)
+
+SELECT a, "b b" FROM "Versioning" WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+ a |    b b     
+---+------------
+ 5 | 2012-01-01
+(1 row)
+
+COMMIT;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- Delete.
+BEGIN;
+DELETE FROM "Versioning" WHERE a = 4;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM "Versioning" ORDER BY a, sys_period;
+ a |    b b     | ?column? 
+---+------------+----------
+ 1 |            | f
+ 2 |            | f
+ 5 | 2012-01-01 | f
+(3 rows)
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM "VersioningHistory" ORDER BY a, sys_period;
+ a | c | ?column? 
+---+---+----------
+ 3 |   | f
+ 4 |   | f
+(2 rows)
+
+SELECT a, "b b" FROM "Versioning" WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+ a | b b 
+---+-----
+(0 rows)
+
+END;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- Delete.
+BEGIN;
+DELETE FROM "Versioning";
+SELECT * FROM "Versioning";
+ a | b b | sys_period 
+---+-----+------------
+(0 rows)
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM "VersioningHistory" ORDER BY a, sys_period;
+ a | c | ?column? 
+---+---+----------
+ 1 |   | t
+ 2 |   | t
+ 3 |   | f
+ 4 |   | f
+ 5 |   | t
+(5 rows)
+
+SELECT a, "b b" FROM "Versioning" WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+ a | b b 
+---+-----
+(0 rows)
+
+END;
+DROP TABLE "Versioning";
+DROP TABLE "VersioningHistory";

--- a/test/runTest.sh
+++ b/test/runTest.sh
@@ -8,7 +8,8 @@ mkdir -p test/result
 TESTS="
   no_history_table no_history_system_period no_system_period
   invalid_system_period_values invalid_system_period invalid_types
-  versioning structure combinations different_schema"
+  versioning versioning_camel_case structure combinations
+  different_schema"
 
 for name in $TESTS; do
   echo ""

--- a/test/runTestNochecks.sh
+++ b/test/runTestNochecks.sh
@@ -5,7 +5,7 @@ psql temporal_tables_test -q -f versioning_function_nochecks.sql
 
 mkdir -p test/result
 
-TESTS="versioning structure combinations different_schema"
+TESTS="versioning versioning_camel_case structure combinations different_schema"
 
 for name in $TESTS; do
   echo ""

--- a/test/sql/versioning_camel_case.sql
+++ b/test/sql/versioning_camel_case.sql
@@ -1,0 +1,90 @@
+CREATE TABLE "Versioning" (a bigint, "b b" date, sys_period tstzrange);
+
+-- Insert some data before versioning is enabled.
+INSERT INTO "Versioning" (a, sys_period) VALUES (1, tstzrange('-infinity', NULL));
+INSERT INTO "Versioning" (a, sys_period) VALUES (2, tstzrange('2000-01-01', NULL));
+
+CREATE TABLE "VersioningHistory" (a bigint, c date, sys_period tstzrange);
+
+CREATE TRIGGER "VersioningTrigger"
+BEFORE INSERT OR UPDATE OR DELETE ON "Versioning"
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', '"VersioningHistory"', false);
+
+-- Insert.
+BEGIN;
+
+INSERT INTO "Versioning" (a) VALUES (3);
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM "Versioning" ORDER BY a, sys_period;
+
+SELECT * FROM "VersioningHistory" ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Update.
+BEGIN;
+
+UPDATE "Versioning" SET a = 4 WHERE a = 3;
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM "Versioning" ORDER BY a, sys_period;
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM "VersioningHistory" ORDER BY a, sys_period;
+
+SELECT a, "b b" FROM "Versioning" WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Multiple updates.
+BEGIN;
+
+UPDATE "Versioning" SET a = 5 WHERE a = 4;
+UPDATE "Versioning" SET "b b" = '2012-01-01' WHERE a = 5;
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM "Versioning" ORDER BY a, sys_period;
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM "VersioningHistory" ORDER BY a, sys_period;
+
+SELECT a, "b b" FROM "Versioning" WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Delete.
+BEGIN;
+
+DELETE FROM "Versioning" WHERE a = 4;
+
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM "Versioning" ORDER BY a, sys_period;
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM "VersioningHistory" ORDER BY a, sys_period;
+
+SELECT a, "b b" FROM "Versioning" WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+
+END;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Delete.
+BEGIN;
+
+DELETE FROM "Versioning";
+
+SELECT * FROM "Versioning";
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM "VersioningHistory" ORDER BY a, sys_period;
+
+SELECT a, "b b" FROM "Versioning" WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+
+END;
+
+DROP TABLE "Versioning";
+DROP TABLE "VersioningHistory";

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -13,7 +13,7 @@ DECLARE
   holder2 record;
   pg_version integer;
 BEGIN
-  -- version 0.2.0
+  -- version 0.3.0
 
   IF TG_WHEN != 'BEFORE' OR TG_LEVEL != 'ROW' THEN
     RAISE TRIGGER_PROTOCOL_VIOLATED USING
@@ -159,12 +159,7 @@ BEGIN
       AND history.attname != sys_period;
 
     EXECUTE ('INSERT INTO ' ||
-      CASE split_part(history_table, '.', 2)
-      WHEN '' THEN
-        quote_ident(history_table)
-      ELSE
-        quote_ident(split_part(history_table, '.', 1)) || '.' || quote_ident(split_part(history_table, '.', 2))
-      END ||
+      history_table ||
       '(' ||
       array_to_string(commonColumns , ',') ||
       ',' ||

--- a/versioning_function_nochecks.sql
+++ b/versioning_function_nochecks.sql
@@ -10,7 +10,7 @@ DECLARE
   transaction_info txid_snapshot;
   existing_range tstzrange;
 BEGIN
-  -- version 0.0.1
+  -- version 0.3.0
 
   sys_period := TG_ARGV[0];
   history_table := TG_ARGV[1];
@@ -56,12 +56,7 @@ BEGIN
       AND history.attname != sys_period;
 
     EXECUTE ('INSERT INTO ' ||
-      CASE split_part(history_table, '.', 2)
-      WHEN '' THEN
-        quote_ident(history_table)
-      ELSE
-        quote_ident(split_part(history_table, '.', 1)) || '.' || quote_ident(split_part(history_table, '.', 2))
-      END ||
+      history_table ||
       '(' ||
       array_to_string(commonColumns , ',') ||
       ',' ||


### PR DESCRIPTION
I decided to remove all unnecessary `quote_ident` usages in the procedure. Since the fix is not backwards compatible, according to https://semver.org, I needed to also bump the first non-zero character in the version, hence the new version is `0.3.0`.

See my motivation in #16 .