### PR TITLE
Add CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: ci
+
+on: [push, pull_request]
+
+env:
+  CI: true
+  PGHOST: localhost
+  PGPORT: 5432
+  PGUSER: postgres
+  PGPASSWORD: postgres
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: ${{ matrix.pg }}
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    strategy:
+      matrix:
+        pg: [postgres:9.5-alpine, postgres:9.6-alpine, postgres:10-alpine]
+
+   steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          make run_test
+
+      - name: Run tests no check
+        run: |
+          make run_test_nochecks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         pg: [postgres:9.5-alpine, postgres:9.6-alpine, postgres:10-alpine]
 
-   steps:
+    steps:
       - uses: actions/checkout@v2
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        pg: [postgres:9.5-alpine, postgres:9.6-alpine, postgres:10-alpine]
+        pg: ["postgres:9.5-alpine", "postgres:9.6-alpine", "postgres:10-alpine"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        pg: ["postgres:9.5-alpine", "postgres:9.6-alpine", "postgres:10-alpine"]
+        pg: ["postgres:9.5-alpine", "postgres:9.6-alpine", "postgres:10-alpine", "postgres:11-alpine", "postgres:12-alpine", "postgres:13-alpine"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Run tests on push and pull request through GitHub Actions.

This was inspired by https://github.com/nearform/temporal_tables/pull/8. I tried to fix the issues in that PR, but ultimately decided to switch to GitHub Actions instead.