### PR TITLE
Fix lost updates with long running transactions

### DIFF
--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -8,7 +8,6 @@ DECLARE
   commonColumns text[];
   time_stamp_to_use timestamptz := current_timestamp;
   range_lower timestamptz;
-  transaction_info txid_snapshot;
   existing_range tstzrange;
   holder record;
   holder2 record;
@@ -63,10 +62,8 @@ BEGIN
   END IF;
 
   IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
-    -- Ignore rows already modified in this transaction
-    transaction_info := txid_current_snapshot();
-    IF OLD.xmin::text >= (txid_snapshot_xmin(transaction_info) % (2^32)::bigint)::text
-    AND OLD.xmin::text <= (txid_snapshot_xmax(transaction_info) % (2^32)::bigint)::text THEN
+    -- Ignore rows already modified in the current transaction
+    IF OLD.xmin::text = (txid_current() % (2^32)::bigint)::text THEN
       IF TG_OP = 'DELETE' THEN
         RETURN OLD;
       END IF;

--- a/versioning_function_nochecks.sql
+++ b/versioning_function_nochecks.sql
@@ -8,7 +8,6 @@ DECLARE
   commonColumns text[];
   time_stamp_to_use timestamptz := current_timestamp;
   range_lower timestamptz;
-  transaction_info txid_snapshot;
   existing_range tstzrange;
 BEGIN
   -- version 0.4.0
@@ -22,10 +21,8 @@ BEGIN
   END IF;
 
   IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
-    -- Ignore rows already modified in this transaction
-    transaction_info := txid_current_snapshot();
-    IF OLD.xmin::text >= (txid_snapshot_xmin(transaction_info) % (2^32)::bigint)::text
-    AND OLD.xmin::text <= (txid_snapshot_xmax(transaction_info) % (2^32)::bigint)::text THEN
+    -- Ignore rows already modified in the current transaction
+    IF OLD.xmin::text = (txid_current() % (2^32)::bigint)::text THEN
       IF TG_OP = 'DELETE' THEN
         RETURN OLD;
       END IF;


### PR DESCRIPTION
The original c extension we aim to be a drop-in replacements
has a check to avoid insterting multiple history rows
in the same transaction
(see https://github.com/arkhipov/temporal_tables/commit/b563fb3fbba203c696a021d89cc71cbc29e8d1d0)

We kept this check in our port, but we introduced a bug in which
updated and deletes from all currently running transactions
may also be discarded, because we check `xmin` against `txid_current_snapshot`.

I fix it as suggested by @kjs222 on #27 by checking it only against `txid_current`.