### PR TITLE
Don't create versions that would be identical to previous version

### DIFF
--- a/test/expected/unchanged_version_values.out
+++ b/test/expected/unchanged_version_values.out
@@ -1,0 +1,58 @@
+CREATE TABLE versioning (a bigint, b bigint, sys_period tstzrange);
+-- Insert some data before versioning is enabled.
+INSERT INTO versioning (a, b, sys_period) VALUES (2, 2, tstzrange('2000-01-01', NULL));
+CREATE TABLE versioning_history (b bigint, sys_period tstzrange);
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_history', false, true);
+-- Update with no changes that would affect history
+BEGIN;
+UPDATE versioning SET a = 3;
+SELECT a, b FROM versioning ORDER BY a, sys_period;
+ a | b
+---+---
+ 3 | 2
+(1 row)
+
+SELECT b, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY b, sys_period;
+ b | ?column? 
+---+----------
+(0 rows)
+
+SELECT a, b FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+ a | b 
+---+---
+(0 rows)
+
+COMMIT;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- Update with changes that would affect history.
+BEGIN;
+UPDATE versioning SET b = 3;
+SELECT a, b, lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+ a | b | ?column? 
+---+---+----------
+ 3 | 3 | t
+(1 row)
+
+SELECT b, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY b, sys_period;
+ b | ?column? 
+---+----------
+ 2 | t
+(1 row)
+
+SELECT a, b FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+ a | b 
+---+---
+ 3 | 3
+(1 row)
+
+COMMIT;
+DROP TABLE versioning;
+DROP TABLE versioning_history;

--- a/test/runTest.sh
+++ b/test/runTest.sh
@@ -9,7 +9,7 @@ TESTS="
   no_history_table no_history_system_period no_system_period
   invalid_system_period_values invalid_system_period invalid_types
   versioning upper_case structure combinations
-  different_schema unchanged_values"
+  different_schema unchanged_values unchanged_version_values"
 
 for name in $TESTS; do
   echo ""

--- a/test/runTestNochecks.sh
+++ b/test/runTestNochecks.sh
@@ -5,7 +5,9 @@ psql temporal_tables_test -q -f versioning_function_nochecks.sql
 
 mkdir -p test/result
 
-TESTS="versioning upper_case structure combinations different_schema unchanged_values"
+TESTS="
+  versioning upper_case structure combinations different_schema unchanged_values
+  unchanged_version_values"
 
 for name in $TESTS; do
   echo ""

--- a/test/sql/unchanged_version_values.sql
+++ b/test/sql/unchanged_version_values.sql
@@ -1,0 +1,42 @@
+CREATE TABLE versioning (a bigint, b bigint, sys_period tstzrange);
+
+-- Insert some data before versioning is enabled.
+INSERT INTO versioning (a, b, sys_period) VALUES (2, 2, tstzrange('2000-01-01', NULL));
+
+CREATE TABLE versioning_history (b bigint, sys_period tstzrange);
+
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_history', false, true);
+
+-- Update with no changes that would affect history
+BEGIN;
+
+UPDATE versioning SET a = 3;
+
+SELECT a, b FROM versioning ORDER BY a, sys_period;
+
+SELECT b, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY b, sys_period;
+
+SELECT a, b FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Update with changes that would affect history.
+BEGIN;
+
+UPDATE versioning SET b = 3;
+
+SELECT a, b, lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+
+SELECT b, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY b, sys_period;
+
+SELECT a, b FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+
+COMMIT;
+
+DROP TABLE versioning;
+DROP TABLE versioning_history;

--- a/versioning_function_nochecks.sql
+++ b/versioning_function_nochecks.sql
@@ -10,6 +10,8 @@ DECLARE
   range_lower timestamptz;
   transaction_info txid_snapshot;
   existing_range tstzrange;
+  newVersion record;
+  oldVersion record;
 BEGIN
   -- version 0.4.0
 
@@ -17,9 +19,6 @@ BEGIN
   history_table := TG_ARGV[1];
   ignore_unchanged_values := TG_ARGV[3];
 
-  IF ignore_unchanged_values AND TG_OP = 'UPDATE' AND NEW IS NOT DISTINCT FROM OLD THEN
-    RETURN OLD;
-  END IF;
 
   IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
     -- Ignore rows already modified in this transaction
@@ -60,7 +59,17 @@ BEGIN
       INNER JOIN main
       ON history.attname = main.attname
       AND history.attname != sys_period;
-
+    -- skip version if it would be identical to the previous version
+    IF ignore_unchanged_values AND TG_OP = 'UPDATE' AND array_length(commonColumns, 1) > 0 THEN      EXECUTE 'SELECT ROW($1.' || array_to_string(commonColumns , ', $1.') || ')'
+        USING NEW
+        INTO newVersion;
+      EXECUTE 'SELECT ROW($1.' || array_to_string(commonColumns , ', $1.') || ')'
+        USING OLD
+        INTO oldVersion;
+      IF newVersion IS NOT DISTINCT FROM oldVersion THEN
+        RETURN NEW;
+      END IF;
+    END IF;
     EXECUTE ('INSERT INTO ' ||
       history_table ||
       '(' ||


### PR DESCRIPTION
I would find it much more useful if the "Ignore updates without actual change" would apply to no actual change _to the version history_, rather than no change to the source table. Why?

- Then you can have columns in the source table that create no new versions if modified by not including those columns in the history table
- Why would you want duplicate, identical rows in the history table anyway?

This is my first time editing plpgsql and it took me a while so I'm kinda opening this for feedback and to start a discussion. Even if this shouldn't be merged (it's backwards incompatible, after all) I would really appreciate any feedback as I'm going to go ahead and use it myself 😬. Maybe this should be controlled by a different option, maybe there's a better way to do this check... just throwing this out there, not saying it should be merged 🙂