### PR TITLE
fix(current_history): Fixed lower range not being set correctly when …

### DIFF
--- a/test/expected/invalid_system_period.out
+++ b/test/expected/invalid_system_period.out
@@ -1,25 +1,25 @@
 CREATE TABLE invalid_system_period (sys_period bigint);
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON invalid_system_period
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, NULL);
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, false);
 INSERT INTO invalid_system_period DEFAULT VALUES;
 ERROR:  system period column "sys_period" of relation "invalid_system_period" is not a range but type bigint
 CREATE TABLE invalid_system_period2 (sys_period tstzrange);
 ALTER TABLE invalid_system_period2 DROP COLUMN sys_period;
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON invalid_system_period2
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, NULL);
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, false);
 INSERT INTO invalid_system_period2 DEFAULT VALUES;
 ERROR:  column "sys_period" of relation "invalid_system_period2" does not exist
 CREATE TABLE invalid_system_period3 (sys_period tstzrange[]);
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON invalid_system_period3
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, NULL);
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, false);
 INSERT INTO invalid_system_period3 DEFAULT VALUES;
 ERROR:  system period column "sys_period" of relation "invalid_system_period3" is not a range but an array
 CREATE TABLE invalid_system_period4 (sys_period tsrange);
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON invalid_system_period4
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, NULL);
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, false);
 INSERT INTO invalid_system_period4 DEFAULT VALUES;
 ERROR:  system period column "sys_period" of relation "invalid_system_period4" is not a range of timestamp with timezone but of type timestamp without time zone

--- a/test/expected/no_system_period.out
+++ b/test/expected/no_system_period.out
@@ -2,6 +2,6 @@ SET client_min_messages TO error;
 CREATE TABLE no_system_period ();
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON no_system_period
-FOR EACH ROW EXECUTE PROCEDURE versioning(NULL, NULL, NULL);
+FOR EACH ROW EXECUTE PROCEDURE versioning(NULL, NULL, false);
 INSERT INTO no_system_period DEFAULT VALUES;
 ERROR:  column "null" of relation "no_system_period" does not exist

--- a/test/expected/set_system_time.out
+++ b/test/expected/set_system_time.out
@@ -9,13 +9,21 @@ FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_history', fa
 -- Insert.
 BEGIN;
 SELECT set_system_time('2001-01-01 22:59:59.001.000234');
-   set_system_time   
+        set_system_time         
 --------------------------------
  2001-01-01 22:59:59.001.000234
 (1 row)
 
 INSERT INTO versioning (a) VALUES (3);
-SELECT * FROM versioning_history;
+SELECT a, "b b", sys_period FROM versioning ORDER BY a, sys_period;
+ a | b b |             sys_period             
+---+-----+------------------------------------
+ 1 |     | [-infinity,)
+ 2 |     | ["2000-01-01 00:00:00+00",)
+ 3 |     | ["2001-01-01 22:59:59.001234+00",)
+(3 rows)
+
+SELECT * FROM versioning_history ORDER BY a, sys_period;
  a | c | sys_period 
 ---+---+------------
 (0 rows)
@@ -23,56 +31,77 @@ SELECT * FROM versioning_history;
 COMMIT;
 -- Update.
 BEGIN;
+SELECT set_system_time('2001-02-01 22:59:59.001.000234');
+        set_system_time         
+--------------------------------
+ 2001-02-01 22:59:59.001.000234
+(1 row)
+
 UPDATE versioning SET a = 4 WHERE a = 3;
-SELECT * FROM versioning_history;
- a | c |         sys_period          
----+---+------------------------------------
- 3 |   | (,"2001-01-01 22:59:59.001234+00")
+SELECT a, "b b", sys_period FROM versioning ORDER BY a, sys_period;
+ a | b b |             sys_period             
+---+-----+------------------------------------
+ 1 |     | [-infinity,)
+ 2 |     | ["2000-01-01 00:00:00+00",)
+ 4 |     | ["2001-02-01 22:59:59.001234+00",)
+(3 rows)
+
+SELECT a, c, sys_period FROM versioning_history ORDER BY a, sys_period;
+ a | c |                            sys_period                             
+---+---+-------------------------------------------------------------------
+ 3 |   | ["2001-01-01 22:59:59.001234+00","2001-02-01 22:59:59.001234+00")
 (1 row)
 
 COMMIT;
--- Reset system time and do multiple updates.
 BEGIN;
+SELECT set_system_time('2001-03-01 22:59:59.001.000234');
+        set_system_time         
+--------------------------------
+ 2001-03-01 22:59:59.001.000234
+(1 row)
+
 UPDATE versioning SET a = 5 WHERE a = 4;
 UPDATE versioning SET "b b" = '2012-01-01' WHERE a = 5;
-SELECT * FROM versioning_history;
- a | c |         sys_period          
----+---+------------------------------------
- 3 |   | (,"2001-01-01 22:59:59.001234+00")
- 4 |   | (,"2001-01-01 22:59:59.001234+00")
+SELECT a, "b b", sys_period FROM versioning ORDER BY a, sys_period;
+ a |    b b     |             sys_period             
+---+------------+------------------------------------
+ 1 |            | [-infinity,)
+ 2 |            | ["2000-01-01 00:00:00+00",)
+ 5 | 2012-01-01 | ["2001-03-01 22:59:59.001234+00",)
+(3 rows)
+
+SELECT a, c, sys_period FROM versioning_history ORDER BY a, sys_period;
+ a | c |                            sys_period                             
+---+---+-------------------------------------------------------------------
+ 3 |   | ["2001-01-01 22:59:59.001234+00","2001-02-01 22:59:59.001234+00")
+ 4 |   | ["2001-02-01 22:59:59.001234+00","2001-03-01 22:59:59.001234+00")
 (2 rows)
 
 COMMIT;
 -- Delete.
 BEGIN;
-SELECT set_system_time('2022-01-11 12:00:00.000.000000');
-   set_system_time   
+SELECT set_system_time('2001-04-01 22:59:59.001.000234');
+        set_system_time         
 --------------------------------
- 2022-01-11 12:00:00.000.000000
+ 2001-04-01 22:59:59.001.000234
 (1 row)
 
 DELETE FROM versioning WHERE a = 4;
-SELECT * FROM versioning_history;
- a | c |         sys_period          
----+---+------------------------------------
- 3 |   | (,"2001-01-01 22:59:59.001234+00")
- 4 |   | (,"2001-01-01 22:59:59.001234+00")
+SELECT a, "b b", sys_period FROM versioning ORDER BY a, sys_period;
+ a |    b b     |             sys_period             
+---+------------+------------------------------------
+ 1 |            | [-infinity,)
+ 2 |            | ["2000-01-01 00:00:00+00",)
+ 5 | 2012-01-01 | ["2001-03-01 22:59:59.001234+00",)
+(3 rows)
+
+SELECT a, c, sys_period FROM versioning_history ORDER BY a, sys_period;
+ a | c |                            sys_period                             
+---+---+-------------------------------------------------------------------
+ 3 |   | ["2001-01-01 22:59:59.001234+00","2001-02-01 22:59:59.001234+00")
+ 4 |   | ["2001-02-01 22:59:59.001234+00","2001-03-01 22:59:59.001234+00")
 (2 rows)
 
-END;
--- Delete.
-BEGIN;
-DELETE FROM versioning;
-SELECT * FROM versioning_history;
- a | c |         sys_period          
----+---+------------------------------------
- 3 |   | (,"2001-01-01 22:59:59.001234+00")
- 4 |   | (,"2001-01-01 22:59:59.001234+00")
- 1 |   | (,"2022-01-11 12:00:00+00")
- 2 |   | (,"2022-01-11 12:00:00+00")
- 5 |   | (,"2022-01-11 12:00:00+00")
-(5 rows)
-
-END;
+COMMIT;
 DROP TABLE versioning;
 DROP TABLE versioning_history;

--- a/test/expected/versioning_including_current_version_in_history.out
+++ b/test/expected/versioning_including_current_version_in_history.out
@@ -5,7 +5,7 @@ INSERT INTO versioning (a, sys_period) VALUES (2, tstzrange('2000-01-01', NULL))
 CREATE TABLE versioning_history (a bigint, c date, sys_period tstzrange);
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON versioning
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_history', false, false, true);
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_history', true, false, true);
 -- Insert.
 BEGIN;
 INSERT INTO versioning (a) VALUES (3);
@@ -52,7 +52,7 @@ SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER
 SELECT a, c, lower(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
  a | c | ?column?
 ---+---+----------
- 3 |   | 
+ 3 |   | f
  4 |   | t
 (2 rows)
 
@@ -61,6 +61,13 @@ SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDE
 ---+-----
  4 |
 (1 row)
+
+SELECT a, c, lower(sys_period) IS NOT NULL FROM versioning_history ORDER BY a, sys_period;
+ a | c | ?column?
+---+---+----------
+ 3 |   | t
+ 4 |   | t
+(2 rows)
 
 COMMIT;
 -- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
@@ -74,7 +81,7 @@ SELECT pg_sleep(0.1);
 BEGIN;
 UPDATE versioning SET a = 5 WHERE a = 4;
 UPDATE versioning SET "b b" = '2012-01-01' WHERE a = 5;
-SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP + interval '1 microseconds' FROM versioning ORDER BY a, sys_period;
  a |    b b     | ?column?
 ---+------------+----------
  1 |            | f
@@ -87,11 +94,20 @@ SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER
 ---+---+----------
  3 |   | f
  4 |   | t
+ 5 |   | f
+ 5 |   |
+(4 rows)
+
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP + interval '1 microseconds' FROM versioning_history ORDER BY a, sys_period;
+ a | c | ?column?
+---+---+----------
+ 3 |   | f
+ 4 |   | f
  5 |   | t
  5 |   |
 (4 rows)
 
-SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP + interval '1 microseconds' ORDER BY a, sys_period;
  a |    b b
 ---+------------
  5 | 2012-01-01

--- a/test/sql/invalid_system_period.sql
+++ b/test/sql/invalid_system_period.sql
@@ -2,7 +2,7 @@ CREATE TABLE invalid_system_period (sys_period bigint);
 
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON invalid_system_period
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, NULL);
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, false);
 
 INSERT INTO invalid_system_period DEFAULT VALUES;
 
@@ -12,7 +12,7 @@ ALTER TABLE invalid_system_period2 DROP COLUMN sys_period;
 
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON invalid_system_period2
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, NULL);
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, false);
 
 INSERT INTO invalid_system_period2 DEFAULT VALUES;
 
@@ -20,7 +20,7 @@ CREATE TABLE invalid_system_period3 (sys_period tstzrange[]);
 
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON invalid_system_period3
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, NULL);
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, false);
 
 INSERT INTO invalid_system_period3 DEFAULT VALUES;
 
@@ -28,6 +28,6 @@ CREATE TABLE invalid_system_period4 (sys_period tsrange);
 
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON invalid_system_period4
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, NULL);
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', NULL, false);
 
 INSERT INTO invalid_system_period4 DEFAULT VALUES;

--- a/test/sql/no_system_period.sql
+++ b/test/sql/no_system_period.sql
@@ -4,6 +4,6 @@ CREATE TABLE no_system_period ();
 
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON no_system_period
-FOR EACH ROW EXECUTE PROCEDURE versioning(NULL, NULL, NULL);
+FOR EACH ROW EXECUTE PROCEDURE versioning(NULL, NULL, false);
 
 INSERT INTO no_system_period DEFAULT VALUES;

--- a/test/sql/set_system_time.sql
+++ b/test/sql/set_system_time.sql
@@ -17,48 +17,48 @@ SELECT set_system_time('2001-01-01 22:59:59.001.000234');
 
 INSERT INTO versioning (a) VALUES (3);
 
-SELECT * FROM versioning_history;
+SELECT a, "b b", sys_period FROM versioning ORDER BY a, sys_period;
+
+SELECT * FROM versioning_history ORDER BY a, sys_period;
 
 COMMIT;
-
 -- Update.
 BEGIN;
 
+SELECT set_system_time('2001-02-01 22:59:59.001.000234');
+
 UPDATE versioning SET a = 4 WHERE a = 3;
 
-SELECT * FROM versioning_history;
+SELECT a, "b b", sys_period FROM versioning ORDER BY a, sys_period;
+
+SELECT a, c, sys_period FROM versioning_history ORDER BY a, sys_period;
 
 COMMIT;
-
--- Reset system time and do multiple updates.
 BEGIN;
+
+SELECT set_system_time('2001-03-01 22:59:59.001.000234');
 
 UPDATE versioning SET a = 5 WHERE a = 4;
 UPDATE versioning SET "b b" = '2012-01-01' WHERE a = 5;
 
-SELECT * FROM versioning_history;
+SELECT a, "b b", sys_period FROM versioning ORDER BY a, sys_period;
+
+SELECT a, c, sys_period FROM versioning_history ORDER BY a, sys_period;
 
 COMMIT;
 
 -- Delete.
 BEGIN;
 
-SELECT set_system_time('2022-01-11 12:00:00.000.000000');
+SELECT set_system_time('2001-04-01 22:59:59.001.000234');
 
 DELETE FROM versioning WHERE a = 4;
 
-SELECT * FROM versioning_history;
+SELECT a, "b b", sys_period FROM versioning ORDER BY a, sys_period;
 
-END;
+SELECT a, c, sys_period FROM versioning_history ORDER BY a, sys_period;
 
--- Delete.
-BEGIN;
-
-DELETE FROM versioning;
-
-SELECT * FROM versioning_history;
-
-END;
+COMMIT;
 
 DROP TABLE versioning;
 DROP TABLE versioning_history;

--- a/test/sql/versioning_including_current_version_in_history.sql
+++ b/test/sql/versioning_including_current_version_in_history.sql
@@ -8,7 +8,7 @@ CREATE TABLE versioning_history (a bigint, c date, sys_period tstzrange);
 
 CREATE TRIGGER versioning_trigger
 BEFORE INSERT OR UPDATE OR DELETE ON versioning
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_history', false, false, true);
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_history', true, false, true);
 
 -- Insert.
 BEGIN;
@@ -37,6 +37,8 @@ SELECT a, c, lower(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER
 
 SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
 
+SELECT a, c, lower(sys_period) IS NOT NULL FROM versioning_history ORDER BY a, sys_period;
+
 COMMIT;
 
 -- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
@@ -48,11 +50,13 @@ BEGIN;
 UPDATE versioning SET a = 5 WHERE a = 4;
 UPDATE versioning SET "b b" = '2012-01-01' WHERE a = 5;
 
-SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning ORDER BY a, sys_period;
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP + interval '1 microseconds' FROM versioning ORDER BY a, sys_period;
 
 SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_history ORDER BY a, sys_period;
 
-SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP ORDER BY a, sys_period;
+SELECT a, c, upper(sys_period) = CURRENT_TIMESTAMP + interval '1 microseconds' FROM versioning_history ORDER BY a, sys_period;
+
+SELECT a, "b b" FROM versioning WHERE lower(sys_period) = CURRENT_TIMESTAMP + interval '1 microseconds' ORDER BY a, sys_period;
 
 COMMIT;
 

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -140,10 +140,10 @@ BEGIN
           time_stamp_to_use := range_lower + interval '1 microseconds';
         END IF;
       END IF;
-      IF range_lower = time_stamp_to_use THEN
+      IF range_lower >= time_stamp_to_use THEN
         RAISE 'system period value of relation "%" cannot be set to a valid period because a row that is attempted to modify was also modified by another transaction', TG_TABLE_NAME USING
         ERRCODE = 'data_exception',
-        DETAIL = 'the start time of the system period is the same as the start time of the current transaction ';
+        DETAIL = 'the start time of the system period is the greater than or equal to the time of the current transaction ';
       END IF;
     END IF;
 

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -6,7 +6,7 @@ DECLARE
   sys_period text;
   history_table text;
   manipulate jsonb;
-  mitigate_update_conflicts bool;
+  mitigate_update_conflicts text;
   ignore_unchanged_values bool;
   include_current_version_in_history bool;
   commonColumns text[];
@@ -53,7 +53,7 @@ BEGIN
 
   sys_period := TG_ARGV[0];
   history_table := TG_ARGV[1];
-  mitigate_update_conflicts := COALESCE(TG_ARGV[2],'false');
+  mitigate_update_conflicts := TG_ARGV[2];
   ignore_unchanged_values := COALESCE(TG_ARGV[3],'false');
   include_current_version_in_history := COALESCE(TG_ARGV[4],'false');
 

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -140,6 +140,11 @@ BEGIN
           time_stamp_to_use := range_lower + interval '1 microseconds';
         END IF;
       END IF;
+      IF range_lower = time_stamp_to_use THEN
+        RAISE 'system period value of relation "%" cannot be set to a valid period because a row that is attempted to modify was also modified by another transaction', TG_TABLE_NAME USING
+        ERRCODE = 'data_exception',
+        DETAIL = 'the start time of the system period is the same as the start time of the current transaction ';
+      END IF;
     END IF;
 
     WITH history AS

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -117,7 +117,7 @@ BEGIN
       HINT = 'history relation must contain system period column with the same name and data type as the versioned one';
     END IF;
 
-    -- If we are not including the current version in the history, we need to check if the current version is valid
+    -- If we we are performing an update or delete, we need to check if the current version is valid and optionally mitigate update conflicts
     IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
       EXECUTE format('SELECT $1.%I', sys_period) USING OLD INTO existing_range;
       

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -6,6 +6,7 @@ DECLARE
   sys_period text;
   history_table text;
   manipulate jsonb;
+  mitigate_update_conflicts bool;
   ignore_unchanged_values bool;
   include_current_version_in_history bool;
   commonColumns text[];
@@ -52,6 +53,7 @@ BEGIN
 
   sys_period := TG_ARGV[0];
   history_table := TG_ARGV[1];
+  mitigate_update_conflicts := COALESCE(TG_ARGV[2],'false');
   ignore_unchanged_values := COALESCE(TG_ARGV[3],'false');
   include_current_version_in_history := COALESCE(TG_ARGV[4],'false');
 
@@ -90,8 +92,7 @@ BEGIN
         IF TG_OP = 'DELETE' THEN
           RETURN OLD;
         END IF;
-
-          RETURN NEW;
+        RETURN NEW;
       END IF;
     END IF;
 
@@ -117,9 +118,9 @@ BEGIN
     END IF;
 
     -- If we are not including the current version in the history, we need to check if the current version is valid
-    IF include_current_version_in_history <> 'true' THEN
+    IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
       EXECUTE format('SELECT $1.%I', sys_period) USING OLD INTO existing_range;
-
+      
       IF existing_range IS NULL THEN
         RAISE 'system period column "%" of relation "%" must not be null', sys_period, TG_TABLE_NAME USING
         ERRCODE = 'null_value_not_allowed';
@@ -131,9 +132,10 @@ BEGIN
         DETAIL = 'valid ranges must be non-empty and unbounded on the high side';
       END IF;
 
-      IF TG_ARGV[2] = 'true' THEN
+      range_lower := lower(existing_range);
+
+      IF mitigate_update_conflicts = 'true' THEN
         -- mitigate update conflicts
-        range_lower := lower(existing_range);
         IF range_lower >= time_stamp_to_use THEN
           time_stamp_to_use := range_lower + interval '1 microseconds';
         END IF;

--- a/versioning_function_nochecks.sql
+++ b/versioning_function_nochecks.sql
@@ -6,7 +6,7 @@ DECLARE
   sys_period text;
   history_table text;
   manipulate jsonb;
-  mitigate_update_conflicts bool;
+  mitigate_update_conflicts text;
   ignore_unchanged_values bool;
   include_current_version_in_history bool;
   commonColumns text[];
@@ -34,7 +34,7 @@ BEGIN
 
   sys_period := TG_ARGV[0];
   history_table := TG_ARGV[1];
-  mitigate_update_conflicts := COALESCE(TG_ARGV[2],'false');
+  mitigate_update_conflicts := TG_ARGV[2];
   ignore_unchanged_values := COALESCE(TG_ARGV[3],'false');
   include_current_version_in_history := COALESCE(TG_ARGV[4],'false');
 

--- a/versioning_function_nochecks.sql
+++ b/versioning_function_nochecks.sql
@@ -56,6 +56,7 @@ BEGIN
       END IF;
     END IF;
 
+    -- If we we are performing an update or delete we might want to optionally mitigate update conflicts
     IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
       EXECUTE format('SELECT $1.%I', sys_period) USING OLD INTO existing_range;
 


### PR DESCRIPTION
- Fix the lower range not being set correctly when including current version in the history table
- Moved mitigate_update_conflicts to be a VAR like other ARG variables
- Added ERROR when a transaction tries to update a row with the same start period as the current transactions timestamp (mimics original extension functionality [here](https://github.com/arkhipov/temporal_tables/blob/master/versioning.c#L843))
- Fixed a small mistake in the system time tests and made them similar to the original extension test cases