### PR TITLE
Fix NULL column issues with "Include the current version in history" mode

### DIFF
--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -217,7 +217,7 @@ BEGIN
           ' = tstzrange($2, $3, ''[)'')' ||
           ' WHERE (' ||
           array_to_string(commonColumns , ',') ||
-          ') = (' ||
+          ') IS NOT DISTINCT FROM ($1.' ||
           array_to_string(commonColumns, ',$1.') ||
           ') AND ' ||
           quote_ident(sys_period) ||

--- a/versioning_function_nochecks.sql
+++ b/versioning_function_nochecks.sql
@@ -109,7 +109,7 @@ BEGIN
           ' = tstzrange($2, $3, ''[)'')' ||
           ' WHERE (' ||
           array_to_string(commonColumns , ',') ||
-          ') = (' ||
+          ') IS NOT DISTINCT FROM ($1.' ||
           array_to_string(commonColumns, ',$1.') ||
           ') AND ' ||
           quote_ident(sys_period) ||


### PR DESCRIPTION
Hey all, thanks for the great SQL trigger. I noticed that the *Include the current version in history* mode wasn't working correctly in our project. The inserts were happening, but the update of the `sys_period` column never happened.

After investigating I found two issues:
1. A missing `$1` at the beginning of the values inside the where comparison. The `$1` was previously added only via join and so only appeared after the second element onwards.
2. Behaviour with null values in columns. The comparison function used `=` to compare all common columns, but stuff like `('A name', null) = ('A name', null)` yields `null` and not `true` and therefore fails the where condition. I replaced the `=` with a `IS NOT DISTINCT FROM`.

Probably we should also add a test case for the null scenario, but this is beyond my knowledge of how this repository works. 