### PR TITLE
Include current history migration documentation and optional auto migration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ FOR EACH ROW EXECUTE PROCEDURE versioning(
 );
 ```
 
+<a name="migration-to-include-current-version-in-history"></a>
+
 ### Migrating to include_current_version_in_history
 
 If you're already using temporal tables and want to adopt the `include_current_version_in_history` feature, follow these steps to safely migrate your existing tables without losing historical data.
@@ -244,7 +246,7 @@ If you're already using temporal tables and want to adopt the `include_current_v
    ```sql
    SELECT DISTINCT trigger_schema, event_object_table 
    FROM information_schema.triggers 
-   WHERE trigger_name = 'versioning_trigger';
+   WHERE trigger_name = 'versioning_trigger'; -- Replace trigger name with the name of the version trigger
    ```
 
 2. **Copy Current Records**
@@ -320,7 +322,7 @@ WHERE UPPER(sys_period) IS NULL;
 
 ### Automatic Migration Mode
 
-When adopting the `include_current_version_in_history` feature for existing tables, you can use the automatic migration mode to seamlessly populate the history table with current records. This eliminates the need for manual intervention.
+When adopting the `include_current_version_in_history` feature for existing tables, you can use the automatic gradual migration mode to seamlessly populate the history table with current records.
 
 The migration mode is enabled by adding a sixth parameter to the versioning trigger:
 
@@ -359,9 +361,11 @@ When migration mode is enabled:
 
 4. **Best Practices**:
    - Enable migration mode only when you're ready to adopt `include_current_version_in_history`
-   - Consider running a test migration on a copy of your data first
+   - Consider running a test migration on a copy of your data first to determine any performance impacts
    - Monitor the size of your history table during migration
    - You can disable migration mode after all records have been migrated
+
+**Note:** The automatic migration happens gradually, filling in missing history only when existing records are updated or deleted. As a result, records that rarely change will still require manual migration using the [method described above](#migration-to-include-current-version-in-history). However, since the most active records will be automatically migrated, the risk of missing important data is greatly reduced, eliminating the need for a dedicated maintenance window.
 
 <a name="migrations"></a>
 

--- a/README.md
+++ b/README.md
@@ -393,7 +393,19 @@ If the column doesn't accept null values you'll need to modify it to allow for n
 
 ## Test
 
-In order to run tests:
+Ensure you have a postgres database available. A database container can be started by running:
+
+```sh
+npm run db:start
+```
+
+In order to run tests
+
+```sh
+npm test
+```
+
+or
 
 ```sh
 make run_test
@@ -408,6 +420,15 @@ make run_test_nochecks
 ```
 
 Obviously, this suite won't run the tests about the error reporting.
+
+**Note:** When running the tests using `make` ensure that the expected environment variables are available
+
+```sh
+PGHOST=localhost
+PGPORT=5432
+PGUSER=postgres
+PGPASSWORD=password
+```
 
 <a name="performance_tests"></a>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.9'
+
+services:
+
+  db:
+    image: postgres:latest
+    container_name: temporal-tables-test
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: postgres
+    ports:  
+      - 5432:5432

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "update-version": "node ./scripts/update-version.js",
     "pretest": "docker run --name temporal-tables-test -e POSTGRES_PASSWORD=password -e POSTGRES_USER=postgres -p 5432:5432 -d postgres:latest && sleep 3 && docker exec temporal-tables-test pg_isready -h localhost -p 5432 -U postgres -t 30",
     "test": "(PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=password make run_test; ret=$?; docker stop temporal-tables-test && docker rm temporal-tables-test; exit $ret)",
+    "test:nochecks": "npm run pretest && (PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=password make run_test_nochecks; ret=$?; docker stop temporal-tables-test && docker rm temporal-tables-test; exit $ret)",
     "cleanup": "docker stop temporal-tables-test || true && docker rm temporal-tables-test || true"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "url": "git+https://github.com/nearform/temporal_tables.git"
   },
   "scripts": {
-    "update-version": "node ./scripts/update-version.js"
+    "update-version": "node ./scripts/update-version.js",
+    "pretest": "docker run --name temporal-tables-test -e POSTGRES_PASSWORD=password -e POSTGRES_USER=postgres -p 5432:5432 -d postgres:latest && sleep 3 && docker exec temporal-tables-test pg_isready -h localhost -p 5432 -U postgres -t 30",
+    "test": "(PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=password make run_test; ret=$?; docker stop temporal-tables-test && docker rm temporal-tables-test; exit $ret)",
+    "cleanup": "docker stop temporal-tables-test || true && docker rm temporal-tables-test || true"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
     "url": "git+https://github.com/nearform/temporal_tables.git"
   },
   "scripts": {
+    "db:start": "docker compose up -d",
+    "db:stop": "docker compose down",
     "update-version": "node ./scripts/update-version.js",
-    "pretest": "docker run --name temporal-tables-test -e POSTGRES_PASSWORD=password -e POSTGRES_USER=postgres -p 5432:5432 -d postgres:latest && sleep 3 && docker exec temporal-tables-test pg_isready -h localhost -p 5432 -U postgres -t 30",
-    "test": "(PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=password make run_test; ret=$?; docker stop temporal-tables-test && docker rm temporal-tables-test; exit $ret)",
-    "test:nochecks": "npm run pretest && (PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=password make run_test_nochecks; ret=$?; docker stop temporal-tables-test && docker rm temporal-tables-test; exit $ret)",
-    "cleanup": "docker stop temporal-tables-test || true && docker rm temporal-tables-test || true"
+    "test": "PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=password make run_test"
   },
   "keywords": [],
   "author": "",

--- a/test/expected/migration_mode.out
+++ b/test/expected/migration_mode.out
@@ -1,56 +1,136 @@
--- Migration Mode Test
-CREATE TABLE versioning_migration (a bigint, "b b" date, sys_period tstzrange);
--- Insert some data before versioning is enabled.
-INSERT INTO versioning_migration (a, "b b", sys_period) VALUES (1, '2020-01-01', tstzrange('2000-01-01', NULL));
-INSERT INTO versioning_migration (a, "b b", sys_period) VALUES (2, '2020-02-01', tstzrange('2000-01-01', NULL));
-CREATE TABLE versioning_migration_history (a bigint, "b b" date, sys_period tstzrange);
--- Create trigger with migration mode enabled
-CREATE TRIGGER versioning_migration_trigger
-BEFORE INSERT OR UPDATE OR DELETE ON versioning_migration
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_migration_history', false, false, true, true);
--- Test migration during update
-BEGIN;
-UPDATE versioning_migration SET "b b" = '2020-03-01' WHERE a = 1;
--- Verify that the current record was migrated to history
-SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration ORDER BY a, sys_period;
- a |    b b     | ?column? 
----+------------+----------
- 1 | 03-01-2020 | t
- 2 | 02-01-2020 | f
-(2 rows)
-
-SELECT a, "b b", upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration_history ORDER BY a, sys_period;
- a |    b b     | ?column? 
----+------------+----------
- 1 | 01-01-2020 | t
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+-- Create the table with various columns
+CREATE TABLE versioned_table (
+    id SERIAL PRIMARY KEY,
+    createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    name TEXT,
+    price NUMERIC(10, 2),
+    is_active BOOLEAN DEFAULT true,
+    event_date DATE,
+    metadata JSONB,
+    unique_key UUID DEFAULT gen_random_uuid(),
+    sys_period tstzrange NOT NULL DEFAULT tstzrange(current_timestamp, null)
+);
+-- create history table
+CREATE TABLE versioned_table_history (LIKE versioned_table);
+-- create trigger for versioning without include current and migration
+CREATE TRIGGER versioned_table_versioning BEFORE
+INSERT
+    OR
+UPDATE
+    OR DELETE ON versioned_table FOR EACH ROW EXECUTE PROCEDURE versioning(
+        'sys_period',
+        'versioned_table_history',
+        true
+    );
+--insert 10 records into the table
+INSERT INTO
+    versioned_table (
+        createdAt,
+        updatedAt,
+        name,
+        price,
+        is_active,
+        event_date,
+        metadata
+    )
+SELECT
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    'Item ' || gs,
+    round((random() * 100) :: numeric, 2),
+    (random() < 0.5),
+    CURRENT_DATE + (gs % 30),
+    jsonb_build_object(
+        'generated_id',
+        gs,
+        'random_val',
+        round((random() * 100) :: numeric, 2)
+    )
+FROM
+    generate_series(1, 10) AS gs;
+-- should return count of 0
+SELECT
+    count(*)
+FROM
+    versioned_table_history;
+ count 
+-------
+     0
 (1 row)
 
-COMMIT;
--- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
-SELECT pg_sleep(0.1);
- pg_sleep 
-----------
-
+-- update a column for all rows
+UPDATE
+    versioned_table
+SET
+    price = round((random() * 100) :: numeric, 2);
+-- should return count of 10
+SELECT
+    count(*)
+FROM
+    versioned_table_history;
+ count 
+-------
+    10
 (1 row)
 
--- Test migration during delete
-BEGIN;
-DELETE FROM versioning_migration WHERE a = 2;
--- Verify that the current record was migrated to history before deletion
-SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration ORDER BY a, sys_period;
- a |    b b     | ?column? 
----+------------+----------
- 1 | 03-01-2020 | f
+-- drop versioning trigger
+DROP TRIGGER IF EXISTS versioned_table_versioning ON versioned_table;
+-- Create trigger with auto_migrate and include_current_version_in_history enabled
+CREATE TRIGGER versioned_table_versioning BEFORE
+INSERT
+    OR
+UPDATE
+    OR DELETE ON versioned_table FOR EACH ROW EXECUTE PROCEDURE versioning(
+        'sys_period',
+        'versioned_table_history',
+        true,
+        false,
+        true,
+        true
+    );
+-- update a column for all rows
+UPDATE
+    versioned_table
+SET
+    price = round((random() * 100) :: numeric, 2);
+-- should return count of 30 as the missing history and the current record should now be in the history table
+SELECT
+    count(*)
+FROM
+    versioned_table_history;
+ count 
+-------
+    30
 (1 row)
 
-SELECT a, "b b", upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration_history ORDER BY a, sys_period;
- a |    b b     | ?column? 
----+------------+----------
- 1 | 01-01-2020 | f
- 2 | 02-01-2020 | t
-(2 rows)
+-- should not return any records
+SELECT
+    count(*),
+    id
+FROM
+    versioned_table_history
+GROUP BY
+    id
+HAVING
+    count(*) != 3;
+ count | id 
+-------+----
+(0 rows)
 
-COMMIT;
--- Cleanup
-DROP TABLE versioning_migration;
-DROP TABLE versioning_migration_history; 
+-- should return count of 10 for the current record of all 10 rows
+SELECT
+    count(*)
+FROM
+    versioned_table_history
+WHERE
+    upper(sys_period) IS NULL;
+ count 
+-------
+    10
+(1 row)
+
+DROP TABLE IF EXISTS versioned_table;
+DROP TABLE IF EXISTS versioned_table_history;
+DROP EXTENSION IF EXISTS pgcrypto;

--- a/test/expected/migration_mode.out
+++ b/test/expected/migration_mode.out
@@ -1,0 +1,56 @@
+-- Migration Mode Test
+CREATE TABLE versioning_migration (a bigint, "b b" date, sys_period tstzrange);
+-- Insert some data before versioning is enabled.
+INSERT INTO versioning_migration (a, "b b", sys_period) VALUES (1, '2020-01-01', tstzrange('2000-01-01', NULL));
+INSERT INTO versioning_migration (a, "b b", sys_period) VALUES (2, '2020-02-01', tstzrange('2000-01-01', NULL));
+CREATE TABLE versioning_migration_history (a bigint, "b b" date, sys_period tstzrange);
+-- Create trigger with migration mode enabled
+CREATE TRIGGER versioning_migration_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning_migration
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_migration_history', false, false, true, true);
+-- Test migration during update
+BEGIN;
+UPDATE versioning_migration SET "b b" = '2020-03-01' WHERE a = 1;
+-- Verify that the current record was migrated to history
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration ORDER BY a, sys_period;
+ a |    b b     | ?column? 
+---+------------+----------
+ 1 | 03-01-2020 | t
+ 2 | 02-01-2020 | f
+(2 rows)
+
+SELECT a, "b b", upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration_history ORDER BY a, sys_period;
+ a |    b b     | ?column? 
+---+------------+----------
+ 1 | 01-01-2020 | t
+(1 row)
+
+COMMIT;
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+ pg_sleep 
+----------
+
+(1 row)
+
+-- Test migration during delete
+BEGIN;
+DELETE FROM versioning_migration WHERE a = 2;
+-- Verify that the current record was migrated to history before deletion
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration ORDER BY a, sys_period;
+ a |    b b     | ?column? 
+---+------------+----------
+ 1 | 03-01-2020 | f
+(1 row)
+
+SELECT a, "b b", upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration_history ORDER BY a, sys_period;
+ a |    b b     | ?column? 
+---+------------+----------
+ 1 | 01-01-2020 | f
+ 2 | 02-01-2020 | t
+(2 rows)
+
+COMMIT;
+-- Cleanup
+DROP TABLE versioning_migration;
+DROP TABLE versioning_migration_history; 

--- a/test/runTest.sh
+++ b/test/runTest.sh
@@ -30,6 +30,7 @@ TESTS="
   non_equality_types non_equality_types_unchanged_values
   set_system_time versioning_including_current_version_in_history
   versioning_rollback_include_current_version_in_history noop_update
+  migration_mode
   "
 
 for name in $TESTS; do

--- a/test/runTestNochecks.sh
+++ b/test/runTestNochecks.sh
@@ -25,6 +25,7 @@ TESTS="
   non_equality_types non_equality_types_unchanged_values
   unchanged_version_values versioning_including_current_version_in_history
   versioning_rollback_include_current_version_in_history noop_update
+  migration_mode
   "
 
 for name in $TESTS; do

--- a/test/sql/migration_mode.sql
+++ b/test/sql/migration_mode.sql
@@ -1,0 +1,42 @@
+-- Migration Mode Test
+CREATE TABLE versioning_migration (a bigint, "b b" date, sys_period tstzrange);
+
+-- Insert some data before versioning is enabled.
+INSERT INTO versioning_migration (a, "b b", sys_period) VALUES (1, '2020-01-01', tstzrange('2000-01-01', NULL));
+INSERT INTO versioning_migration (a, "b b", sys_period) VALUES (2, '2020-02-01', tstzrange('2000-01-01', NULL));
+
+CREATE TABLE versioning_migration_history (a bigint, "b b" date, sys_period tstzrange);
+
+-- Create trigger with migration mode enabled
+CREATE TRIGGER versioning_migration_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON versioning_migration
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_migration_history', false, false, true, true);
+
+-- Test migration during update
+BEGIN;
+
+UPDATE versioning_migration SET "b b" = '2020-03-01' WHERE a = 1;
+
+-- Verify that the current record was migrated to history
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration ORDER BY a, sys_period;
+SELECT a, "b b", upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration_history ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
+SELECT pg_sleep(0.1);
+
+-- Test migration during delete
+BEGIN;
+
+DELETE FROM versioning_migration WHERE a = 2;
+
+-- Verify that the current record was migrated to history before deletion
+SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration ORDER BY a, sys_period;
+SELECT a, "b b", upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration_history ORDER BY a, sys_period;
+
+COMMIT;
+
+-- Cleanup
+DROP TABLE versioning_migration;
+DROP TABLE versioning_migration_history; 

--- a/test/sql/migration_mode.sql
+++ b/test/sql/migration_mode.sql
@@ -1,42 +1,128 @@
--- Migration Mode Test
-CREATE TABLE versioning_migration (a bigint, "b b" date, sys_period tstzrange);
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
--- Insert some data before versioning is enabled.
-INSERT INTO versioning_migration (a, "b b", sys_period) VALUES (1, '2020-01-01', tstzrange('2000-01-01', NULL));
-INSERT INTO versioning_migration (a, "b b", sys_period) VALUES (2, '2020-02-01', tstzrange('2000-01-01', NULL));
+-- Create the table with various columns
+CREATE TABLE versioned_table (
+    id SERIAL PRIMARY KEY,
+    createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    name TEXT,
+    price NUMERIC(10, 2),
+    is_active BOOLEAN DEFAULT true,
+    event_date DATE,
+    metadata JSONB,
+    unique_key UUID DEFAULT gen_random_uuid(),
+    sys_period tstzrange NOT NULL DEFAULT tstzrange(current_timestamp, null)
+);
 
-CREATE TABLE versioning_migration_history (a bigint, "b b" date, sys_period tstzrange);
+-- create history table
+CREATE TABLE versioned_table_history (LIKE versioned_table);
 
--- Create trigger with migration mode enabled
-CREATE TRIGGER versioning_migration_trigger
-BEFORE INSERT OR UPDATE OR DELETE ON versioning_migration
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'versioning_migration_history', false, false, true, true);
+-- create trigger for versioning without include current and migration
+CREATE TRIGGER versioned_table_versioning BEFORE
+INSERT
+    OR
+UPDATE
+    OR DELETE ON versioned_table FOR EACH ROW EXECUTE PROCEDURE versioning(
+        'sys_period',
+        'versioned_table_history',
+        true
+    );
 
--- Test migration during update
-BEGIN;
+--insert 10 records into the table
+INSERT INTO
+    versioned_table (
+        createdAt,
+        updatedAt,
+        name,
+        price,
+        is_active,
+        event_date,
+        metadata
+    )
+SELECT
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    'Item ' || gs,
+    round((random() * 100) :: numeric, 2),
+    (random() < 0.5),
+    CURRENT_DATE + (gs % 30),
+    jsonb_build_object(
+        'generated_id',
+        gs,
+        'random_val',
+        round((random() * 100) :: numeric, 2)
+    )
+FROM
+    generate_series(1, 10) AS gs;
 
-UPDATE versioning_migration SET "b b" = '2020-03-01' WHERE a = 1;
+-- should return count of 0
+SELECT
+    count(*)
+FROM
+    versioned_table_history;
 
--- Verify that the current record was migrated to history
-SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration ORDER BY a, sys_period;
-SELECT a, "b b", upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration_history ORDER BY a, sys_period;
+-- update a column for all rows
+UPDATE
+    versioned_table
+SET
+    price = round((random() * 100) :: numeric, 2);
 
-COMMIT;
+-- should return count of 10
+SELECT
+    count(*)
+FROM
+    versioned_table_history;
 
--- Make sure that the next transaction's CURRENT_TIMESTAMP is different.
-SELECT pg_sleep(0.1);
+-- drop versioning trigger
+DROP TRIGGER IF EXISTS versioned_table_versioning ON versioned_table;
 
--- Test migration during delete
-BEGIN;
+-- Create trigger with auto_migrate and include_current_version_in_history enabled
+CREATE TRIGGER versioned_table_versioning BEFORE
+INSERT
+    OR
+UPDATE
+    OR DELETE ON versioned_table FOR EACH ROW EXECUTE PROCEDURE versioning(
+        'sys_period',
+        'versioned_table_history',
+        true,
+        false,
+        true,
+        true
+    );
 
-DELETE FROM versioning_migration WHERE a = 2;
+-- update a column for all rows
+UPDATE
+    versioned_table
+SET
+    price = round((random() * 100) :: numeric, 2);
 
--- Verify that the current record was migrated to history before deletion
-SELECT a, "b b", lower(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration ORDER BY a, sys_period;
-SELECT a, "b b", upper(sys_period) = CURRENT_TIMESTAMP FROM versioning_migration_history ORDER BY a, sys_period;
+-- should return count of 30 as the missing history and the current record should now be in the history table
+SELECT
+    count(*)
+FROM
+    versioned_table_history;
 
-COMMIT;
+-- should not return any records
+SELECT
+    count(*),
+    id
+FROM
+    versioned_table_history
+GROUP BY
+    id
+HAVING
+    count(*) != 3;
 
--- Cleanup
-DROP TABLE versioning_migration;
-DROP TABLE versioning_migration_history; 
+-- should return count of 10 for the current record of all 10 rows
+SELECT
+    count(*)
+FROM
+    versioned_table_history
+WHERE
+    upper(sys_period) IS NULL;
+
+DROP TABLE IF EXISTS versioned_table;
+
+DROP TABLE IF EXISTS versioned_table_history;
+
+DROP EXTENSION IF EXISTS pgcrypto;

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -199,7 +199,7 @@ BEGIN
       AND history.attname != sys_period;
 
     -- Check if record exists in history table for migration mode
-    IF enable_migration_mode = 'true' AND (TG_OP = 'UPDATE' OR TG_OP = 'DELETE') THEN
+    IF enable_migration_mode = 'true' AND include_current_version_in_history = 'true' AND (TG_OP = 'UPDATE' OR TG_OP = 'DELETE') THEN
       EXECUTE 'SELECT EXISTS (
           SELECT 1 FROM ' || history_table || ' WHERE ROW(' ||
           array_to_string(commonColumns, ',') ||

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -237,7 +237,7 @@ BEGIN
     END IF;
 
     -- If we are including the current version in the history and the operation is an update or delete, we need to update the previous version in the history table
-    IF include_current_version_in_history = 'true' AND enable_migration_mode = 'false' THEN
+    IF include_current_version_in_history = 'true' THEN
       IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
         EXECUTE (
           'UPDATE ' ||
@@ -269,7 +269,7 @@ BEGIN
           ',tstzrange($2, NULL, ''[)''))')
           USING NEW, time_stamp_to_use;
       END IF;
-    ELSIF enable_migration_mode = 'false' THEN
+    ELSE
       EXECUTE ('INSERT INTO ' ||
       history_table ||
       '(' ||

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -282,15 +282,6 @@ BEGIN
        USING OLD, range_lower, time_stamp_to_use;
     END IF;
 
-    -- Update the sys_period in the current record
-    IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' THEN
-      NEW.sys_period := tstzrange(time_stamp_to_use, NULL, '[)');
-      RETURN NEW;
-    ELSIF TG_OP = 'DELETE' THEN
-      RETURN OLD;
-    END IF;
-
-    RETURN NULL;
   END IF;
 
   IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' THEN

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -9,6 +9,7 @@ DECLARE
   mitigate_update_conflicts text;
   ignore_unchanged_values bool;
   include_current_version_in_history bool;
+  enable_migration_mode bool;
   commonColumns text[];
   time_stamp_to_use timestamptz;
   range_lower timestamptz;
@@ -19,6 +20,7 @@ DECLARE
   newVersion record;
   oldVersion record;
   user_defined_system_time text;
+  record_exists bool;
 BEGIN
   -- set custom system time if exists
   BEGIN
@@ -45,10 +47,10 @@ BEGIN
     MESSAGE = 'function "versioning" must be fired for INSERT or UPDATE or DELETE';
   END IF;
 
-  IF TG_NARGS not between 3 and 5 THEN
+  IF TG_NARGS not between 3 and 6 THEN
     RAISE INVALID_PARAMETER_VALUE USING
     MESSAGE = 'wrong number of parameters for function "versioning"',
-    HINT = 'expected 3 to 5 parameters but got ' || TG_NARGS;
+    HINT = 'expected 3 to 6 parameters but got ' || TG_NARGS;
   END IF;
 
   sys_period := TG_ARGV[0];
@@ -56,6 +58,7 @@ BEGIN
   mitigate_update_conflicts := TG_ARGV[2];
   ignore_unchanged_values := COALESCE(TG_ARGV[3],'false');
   include_current_version_in_history := COALESCE(TG_ARGV[4],'false');
+  enable_migration_mode := COALESCE(TG_ARGV[5],'false');
 
   IF ignore_unchanged_values AND TG_OP = 'UPDATE' THEN
     IF NEW IS NOT DISTINCT FROM OLD THEN
@@ -194,6 +197,32 @@ BEGIN
       INNER JOIN main
       ON history.attname = main.attname
       AND history.attname != sys_period;
+
+    -- Check if record exists in history table for migration mode
+    IF enable_migration_mode = 'true' AND (TG_OP = 'UPDATE' OR TG_OP = 'DELETE') THEN
+      EXECUTE 'SELECT EXISTS (
+          SELECT 1 FROM ' || history_table || ' WHERE ROW(' ||
+          array_to_string(commonColumns, ',') ||
+          ') IS NOT DISTINCT FROM ROW($1.' ||
+          array_to_string(commonColumns, ',$1.') ||
+          '))'
+      USING OLD INTO record_exists;
+
+      IF NOT record_exists THEN
+        -- Insert current record into history table with its original range
+        EXECUTE 'INSERT INTO ' ||
+          history_table ||
+          '(' ||
+          array_to_string(commonColumns, ',') ||
+          ',' ||
+          quote_ident(sys_period) ||
+          ') VALUES ($1.' ||
+          array_to_string(commonColumns, ',$1.') ||
+          ',tstzrange($2, $3, ''[)''))'
+        USING OLD, range_lower, time_stamp_to_use;
+      END IF;
+    END IF;
+
     -- skip version if it would be identical to the previous version
     IF ignore_unchanged_values AND TG_OP = 'UPDATE' AND array_length(commonColumns, 1) > 0 THEN
       EXECUTE 'SELECT ROW($1.' || array_to_string(commonColumns , ', $1.') || ')'
@@ -206,8 +235,9 @@ BEGIN
         RETURN NEW;
       END IF;
     END IF;
+
     -- If we are including the current version in the history and the operation is an update or delete, we need to update the previous version in the history table
-    IF include_current_version_in_history = 'true' THEN
+    IF include_current_version_in_history = 'true' AND enable_migration_mode = 'false' THEN
       IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
         EXECUTE (
           'UPDATE ' ||
@@ -239,7 +269,7 @@ BEGIN
           ',tstzrange($2, NULL, ''[)''))')
           USING NEW, time_stamp_to_use;
       END IF;
-    ELSE
+    ELSIF enable_migration_mode = 'false' THEN
       EXECUTE ('INSERT INTO ' ||
       history_table ||
       '(' ||
@@ -251,6 +281,16 @@ BEGIN
       ',tstzrange($2, $3, ''[)''))')
        USING OLD, range_lower, time_stamp_to_use;
     END IF;
+
+    -- Update the sys_period in the current record
+    IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' THEN
+      NEW.sys_period := tstzrange(time_stamp_to_use, NULL, '[)');
+      RETURN NEW;
+    ELSIF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    END IF;
+
+    RETURN NULL;
   END IF;
 
   IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' THEN

--- a/versioning_function_nochecks.sql
+++ b/versioning_function_nochecks.sql
@@ -92,7 +92,7 @@ BEGIN
       AND history.attname != sys_period;
 
     -- Check if record exists in history table for migration mode
-    IF enable_migration_mode = 'true' AND (TG_OP = 'UPDATE' OR TG_OP = 'DELETE') THEN
+    IF enable_migration_mode = 'true' AND include_current_version_in_history = 'true' AND (TG_OP = 'UPDATE' OR TG_OP = 'DELETE') THEN
       EXECUTE 'SELECT EXISTS (
           SELECT 1 FROM ' || history_table || ' WHERE ROW(' ||
           array_to_string(commonColumns, ',') ||

--- a/versioning_function_nochecks.sql
+++ b/versioning_function_nochecks.sql
@@ -9,6 +9,7 @@ DECLARE
   mitigate_update_conflicts text;
   ignore_unchanged_values bool;
   include_current_version_in_history bool;
+  enable_migration_mode bool;
   commonColumns text[];
   time_stamp_to_use timestamptz;
   range_lower timestamptz;
@@ -16,6 +17,7 @@ DECLARE
   newVersion record;
   oldVersion record;
   user_defined_system_time text;
+  record_exists bool;
 BEGIN
   -- set custom system time if exists
   BEGIN
@@ -37,6 +39,7 @@ BEGIN
   mitigate_update_conflicts := TG_ARGV[2];
   ignore_unchanged_values := COALESCE(TG_ARGV[3],'false');
   include_current_version_in_history := COALESCE(TG_ARGV[4],'false');
+  enable_migration_mode := COALESCE(TG_ARGV[5],'false');
 
   IF ignore_unchanged_values AND TG_OP = 'UPDATE' THEN
     IF NEW IS NOT DISTINCT FROM OLD THEN
@@ -87,8 +90,35 @@ BEGIN
       INNER JOIN main
       ON history.attname = main.attname
       AND history.attname != sys_period;
+
+    -- Check if record exists in history table for migration mode
+    IF enable_migration_mode = 'true' AND (TG_OP = 'UPDATE' OR TG_OP = 'DELETE') THEN
+      EXECUTE 'SELECT EXISTS (
+          SELECT 1 FROM ' || history_table || ' WHERE ROW(' ||
+          array_to_string(commonColumns, ',') ||
+          ') IS NOT DISTINCT FROM ROW($1.' ||
+          array_to_string(commonColumns, ',$1.') ||
+          '))'
+      USING OLD INTO record_exists;
+
+      IF NOT record_exists THEN
+        -- Insert current record into history table with its original range
+        EXECUTE 'INSERT INTO ' ||
+          history_table ||
+          '(' ||
+          array_to_string(commonColumns, ',') ||
+          ',' ||
+          quote_ident(sys_period) ||
+          ') VALUES ($1.' ||
+          array_to_string(commonColumns, ',$1.') ||
+          ',tstzrange($2, $3, ''[)''))'
+        USING OLD, range_lower, time_stamp_to_use;
+      END IF;
+    END IF;
+
     -- skip version if it would be identical to the previous version
-    IF ignore_unchanged_values AND TG_OP = 'UPDATE' AND array_length(commonColumns, 1) > 0 THEN      EXECUTE 'SELECT ROW($1.' || array_to_string(commonColumns , ', $1.') || ')'
+    IF ignore_unchanged_values AND TG_OP = 'UPDATE' AND array_length(commonColumns, 1) > 0 THEN
+      EXECUTE 'SELECT ROW($1.' || array_to_string(commonColumns , ', $1.') || ')'
         USING NEW
         INTO newVersion;
       EXECUTE 'SELECT ROW($1.' || array_to_string(commonColumns , ', $1.') || ')'
@@ -98,7 +128,8 @@ BEGIN
         RETURN NEW;
       END IF;
     END IF;
--- If we are including the current version in the history and the operation is an update or delete, we need to update the previous version in the history table
+
+    -- If we are including the current version in the history and the operation is an update or delete, we need to update the previous version in the history table
     IF include_current_version_in_history = 'true' THEN
       IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
         EXECUTE (


### PR DESCRIPTION
* Documentation on how to adopt the include current history feature for existing users of temporal tables
* Migration mode that enables gradual migration for records overtime
  * The idea is this will do the hard work for "actively" mutated records over a period of time, at which point the remainder of the records can be manually migrated reducing the risk of missing history

Resolves https://github.com/nearform/temporal_tables/issues/87